### PR TITLE
feat(meta): add C99, C++, and MATLAB/Octave code generation targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.36.0"
+version = "0.37.0"
 
 [project.optional-dependencies]
 jax = [

--- a/src/mxlpy/meta/codegen_model.py
+++ b/src/mxlpy/meta/codegen_model.py
@@ -9,8 +9,11 @@ from mxlpy.meta.sympy_tools import (
     fn_to_sympy,
     list_of_symbols,
     stoichiometries_to_sympy,
+    sympy_to_inline_c,
+    sympy_to_inline_cxx,
     sympy_to_inline_js,
     sympy_to_inline_julia,
+    sympy_to_inline_matlab,
     sympy_to_inline_py,
     sympy_to_inline_rust,
 )
@@ -23,7 +26,10 @@ if TYPE_CHECKING:
     from mxlpy.model import Model
 
 __all__ = [
+    "generate_model_code_c",
+    "generate_model_code_cpp",
     "generate_model_code_jl",
+    "generate_model_code_matlab",
     "generate_model_code_py",
     "generate_model_code_rs",
     "generate_model_code_ts",
@@ -45,6 +51,8 @@ def _generate_model_code(
     imports: list[str] | None = None,
     end: str | None = None,
     free_parameters: list[str] | None = None,
+    variables_formatter: Callable[[list[str]], str] | None = None,
+    return_formatter: Callable[[list[str]], str] | None = None,
 ) -> str:
     source: list[str] = []
     # Model components
@@ -60,7 +68,10 @@ def _generate_model_code(
         source.append(model_fn.format(n=len(variables)))
 
     if len(variables) > 0:
-        source.append(variables_template.format(", ".join(variables)))
+        if variables_formatter is not None:
+            source.append(variables_formatter(list(variables.keys())))
+        else:
+            source.append(variables_template.format(", ".join(variables)))
 
     # Parameters
     if free_parameters is not None:
@@ -123,8 +134,11 @@ def _generate_model_code(
 
     # Return
     ret_order = [i for i in variables if i in diff_eqs]
-    ret = ", ".join(f"d{i}dt" for i in ret_order) if len(diff_eqs) > 0 else "()"
-    source.append(return_template.format(ret))
+    if return_formatter is not None:
+        source.append(return_formatter(ret_order))
+    else:
+        ret = ", ".join(f"d{i}dt" for i in ret_order) if len(diff_eqs) > 0 else "()"
+        source.append(return_template.format(ret))
 
     if end is not None:
         source.append(end)
@@ -137,6 +151,8 @@ def generate_model_code_py(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    *,
+    typed: bool = True,
 ) -> str:
     """Transform the model into a python function, inlining the function calls.
 
@@ -172,7 +188,7 @@ def generate_model_code_py(
         sized=False,
         model_fn=model_fn,
         variables_template="    {} = variables",
-        assignment_template="    {k}: float = {v}",
+        assignment_template="    {k}: float = {v}" if typed else "    {k} = {v}",
         sympy_inline_fn=sympy_to_inline_py,
         return_template="    return {}",
         end=None,
@@ -298,12 +314,154 @@ def generate_model_code_jl(
     return _generate_model_code(
         model,
         imports=None,
+        sized=False,
+        model_fn=model_fn,
+        variables_template="    {} = variables",
+        assignment_template="    {k} = {v}",
+        sympy_inline_fn=sympy_to_inline_julia,
+        return_template="    return [{}]",
+        end="end",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_code_c(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model into a C99 function, inlining the function calls.
+
+    The generated function writes derivatives into an output pointer ``dydt``
+    rather than returning an array, since C does not support returning arrays.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        C99 source code of the generated model function
+
+    """
+    if free_parameters is None:
+        model_fn = "void model(double t, const double *variables, double *dydt) {"
+    else:
+        args_typed = ", ".join(f"double {k}" for k in free_parameters)
+        model_fn = f"void model(double t, const double *variables, double *dydt, {args_typed}) {{"
+
+    return _generate_model_code(
+        model,
+        imports=["#include <math.h>", ""],
+        sized=False,
+        model_fn=model_fn,
+        variables_template="",  # unused — variables_formatter takes over
+        assignment_template="    double {k} = {v};",
+        sympy_inline_fn=sympy_to_inline_c,
+        return_template="",  # unused — return_formatter takes over
+        end="}",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+        variables_formatter=lambda vs: "\n".join(
+            f"    double {v} = variables[{i}];" for i, v in enumerate(vs)
+        ),
+        return_formatter=lambda ret_vars: "\n".join(
+            f"    dydt[{i}] = d{v}dt;" for i, v in enumerate(ret_vars)
+        ),
+    )
+
+
+def generate_model_code_cpp(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model into a c++ function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        C++ source code of the generated model function
+
+    """
+    if free_parameters is None:
+        model_fn = "std::array<double, {n}> model(double time, const std::array<double, {n}>& variables) {{"
+    else:
+        args_typed = ", ".join(f"double {k}" for k in free_parameters)
+        model_fn = f"std::array<double, {{n}}> model(double time, const std::array<double, {{n}}>& variables, {args_typed}) {{{{"
+
+    return _generate_model_code(
+        model,
         sized=True,
         model_fn=model_fn,
-        variables_template="    {} = *variables",
-        assignment_template="    k = {v}",
-        sympy_inline_fn=sympy_to_inline_julia,
-        return_template="    return {}",
+        variables_template="    const auto [{}] = variables;",
+        assignment_template="    double {k} = {v};",
+        sympy_inline_fn=sympy_to_inline_cxx,
+        return_template="    return {{{}}};",
+        imports=[
+            "#include <array>",
+            "#include <cmath>",
+            "",
+        ],
+        end="}",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_code_matlab(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model into a MATLAB/Octave function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        MATLAB/Octave source code of the generated model function
+
+    """
+    if free_parameters is None:
+        model_fn = "function dydt = model(t, variables)"
+    else:
+        args = ", ".join(k for k in free_parameters)
+        model_fn = f"function dydt = model(t, variables, {args})"
+
+    return _generate_model_code(
+        model,
+        imports=None,
+        sized=False,
+        model_fn=model_fn,
+        variables_template="    [{}] = num2cell(variables){{:}};",
+        assignment_template="    {k} = {v};",
+        sympy_inline_fn=sympy_to_inline_matlab,
+        return_template="    dydt = [{}]';",
         end="end",
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,

--- a/src/mxlpy/meta/sympy_tools.py
+++ b/src/mxlpy/meta/sympy_tools.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 import sympy
-from sympy.printing import jscode, julia_code, rust_code
-from sympy.printing.pycode import pycode
 
 from mxlpy.meta.source_tools import fn_to_sympy
 from mxlpy.types import Derived
@@ -17,6 +15,7 @@ if TYPE_CHECKING:
 __all__ = [
     "list_of_symbols",
     "stoichiometries_to_sympy",
+    "sympy_to_inline_c",
     "sympy_to_inline_js",
     "sympy_to_inline_julia",
     "sympy_to_inline_py",
@@ -64,7 +63,24 @@ def sympy_to_inline_py(expr: sympy.Expr) -> str:
     'x**2 + 2*x + 1'
 
     """
-    return cast(str, pycode(expr, fully_qualified_modules=True, full_prec=False))
+    return cast(str, sympy.pycode(expr, fully_qualified_modules=True, full_prec=False))
+
+
+def sympy_to_inline_c(expr: sympy.Expr) -> str:
+    """Create C99 code from sympy expression.
+
+    Parameters
+    ----------
+    expr
+        Sympy expression to convert
+
+    Returns
+    -------
+    str
+        C99 code string
+
+    """
+    return cast(str, sympy.ccode(expr, full_prec=False))
 
 
 def sympy_to_inline_js(expr: sympy.Expr) -> str:
@@ -81,7 +97,7 @@ def sympy_to_inline_js(expr: sympy.Expr) -> str:
         JavaScript code string
 
     """
-    return cast(str, jscode(expr, full_prec=False))
+    return cast(str, sympy.jscode(expr, full_prec=False))
 
 
 def sympy_to_inline_rust(expr: sympy.Expr) -> str:
@@ -98,7 +114,7 @@ def sympy_to_inline_rust(expr: sympy.Expr) -> str:
         Rust code string
 
     """
-    return cast(str, rust_code(expr, full_prec=False))
+    return cast(str, sympy.rust_code(expr, full_prec=False))
 
 
 def sympy_to_inline_julia(expr: sympy.Expr) -> str:
@@ -115,7 +131,41 @@ def sympy_to_inline_julia(expr: sympy.Expr) -> str:
         Julia code string
 
     """
-    return cast(str, julia_code(expr, full_prec=False))
+    return cast(str, sympy.julia_code(expr, full_prec=False))
+
+
+def sympy_to_inline_matlab(expr: sympy.Expr) -> str:
+    """Create Julia code from sympy expression.
+
+    Parameters
+    ----------
+    expr
+        Sympy expression to convert
+
+    Returns
+    -------
+    str
+        Julia code string
+
+    """
+    return cast(str, sympy.octave_code(expr, full_prec=False))
+
+
+def sympy_to_inline_cxx(expr: sympy.Expr) -> str:
+    """Create Julia code from sympy expression.
+
+    Parameters
+    ----------
+    expr
+        Sympy expression to convert
+
+    Returns
+    -------
+    str
+        Julia code string
+
+    """
+    return cast(str, sympy.cxxcode(expr, full_prec=False))
 
 
 def sympy_to_python_fn(
@@ -153,7 +203,7 @@ def sympy_to_python_fn(
     fn_args = ", ".join(f"{i}: float" for i in args)
 
     return f"""def {fn_name}({fn_args}) -> float:
-    return {pycode(expr, fully_qualified_modules=True, full_prec=False)}
+    return {sympy.pycode(expr, fully_qualified_modules=True, full_prec=False)}
     """.replace("math.factorial", "scipy.special.factorial")
 
 


### PR DESCRIPTION
## Summary

- Adds `generate_model_code_c` — C99 output using a pointer-based `dydt` output array
- Adds `generate_model_code_cpp` — C++ output using `std::array` with structured bindings and `<cmath>`
- Adds `generate_model_code_matlab` — MATLAB/Octave output using `num2cell` for variable unpacking and a column-vector return
- Fixes the Julia backend (wrong destructuring pattern and missing `[…]` return brackets)
- Adds a `typed: bool` flag to `generate_model_code_py` to optionally suppress type annotations
- Extends `_generate_model_code` with `variables_formatter` and `return_formatter` callbacks for per-language control over variable unpacking and derivative emission
- Consolidates sympy printer imports to use the `sympy.*` namespace directly (removes sub-module imports)

## Test plan

- [ ] Run `generate_model_code_c` on an example model and verify the emitted C99 compiles with `gcc -std=c99`
- [ ] Run `generate_model_code_cpp` and verify the emitted C++ compiles with `g++ -std=c++17`
- [ ] Run `generate_model_code_matlab` and verify the emitted function runs correctly in Octave
- [ ] Run existing codegen tests to confirm Python, Rust, Julia, and JS backends are unaffected
- [ ] Run `uv run pytest --disable-warnings --cov tests/` and confirm no regressions