### PR TITLE
feat(meta): expand codegen with components functions, identifier sanitization, and output subsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ venv.bak/
 # temporary files and folders
 *temp*
 tmp
+src/mxlbricks
+
 # pixi environments
 .pixi
 *.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.37.0"
+version = "0.38.0"
 
 [project.optional-dependencies]
 jax = [

--- a/src/mxlpy/meta/codegen_model.py
+++ b/src/mxlpy/meta/codegen_model.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, cast
+
+import sympy
 
 from mxlpy.meta.sympy_tools import (
     fn_to_sympy,
@@ -21,8 +24,6 @@ from mxlpy.meta.sympy_tools import (
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    import sympy
-
     from mxlpy.model import Model
 
 __all__ = [
@@ -33,9 +34,40 @@ __all__ = [
     "generate_model_code_py",
     "generate_model_code_rs",
     "generate_model_code_ts",
+    "generate_model_components_c",
+    "generate_model_components_cpp",
+    "generate_model_components_jl",
+    "generate_model_components_matlab",
+    "generate_model_components_py",
+    "generate_model_components_rs",
+    "generate_model_components_ts",
 ]
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _to_valid_identifier(name: str) -> str:
+    """Convert an arbitrary string to a valid identifier.
+
+    Uses C99 identifier rules ([a-zA-Z_][a-zA-Z0-9_]*), which are the
+    strictest common denominator across all supported target languages
+    (C, C++, Rust, TypeScript, Julia, MATLAB/Octave, Python).
+
+    Parameters
+    ----------
+    name
+        Original component name from the model
+
+    Returns
+    -------
+    str
+        Sanitized identifier safe for use in all target languages
+
+    """
+    sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", name)
+    if sanitized and sanitized[0].isdigit():
+        sanitized = "_" + sanitized
+    return sanitized or "_"
 
 
 def _generate_model_code(
@@ -43,21 +75,40 @@ def _generate_model_code(
     *,
     sized: bool,
     model_fn: str,
-    variables_template: str,
     assignment_template: str,
     sympy_inline_fn: Callable[[sympy.Expr], str],
-    return_template: str,
+    variables_formatter: Callable[[list[str]], str],
+    return_formatter: Callable[[list[str]], str],
     custom_fns: dict[str, sympy.Expr],
     imports: list[str] | None = None,
     end: str | None = None,
     free_parameters: list[str] | None = None,
-    variables_formatter: Callable[[list[str]], str] | None = None,
-    return_formatter: Callable[[list[str]], str] | None = None,
 ) -> str:
     source: list[str] = []
     # Model components
     variables = model.get_initial_conditions()
     parameters = model.get_parameter_values()
+
+    # Build sanitized name map for all model component names
+    all_names = (
+        list(variables)
+        + list(parameters)
+        + list(model.get_raw_derived())
+        + list(model.get_raw_reactions())
+    )
+    name_map = {n: _to_valid_identifier(n) for n in all_names}
+    sanitized_names = list(name_map.values())
+    if len(sanitized_names) != len(set(sanitized_names)):
+        _LOGGER.warning(
+            "Name sanitization produced duplicate identifiers — "
+            "rename model components to avoid collisions."
+        )
+    # Sympy substitution list: replace symbols with original names by sanitized ones
+    sym_subs = [
+        (sympy.Symbol(orig), sympy.Symbol(san))
+        for orig, san in name_map.items()
+        if orig != san
+    ]
 
     if imports is not None:
         source.extend(imports)
@@ -68,10 +119,7 @@ def _generate_model_code(
         source.append(model_fn.format(n=len(variables)))
 
     if len(variables) > 0:
-        if variables_formatter is not None:
-            source.append(variables_formatter(list(variables.keys())))
-        else:
-            source.append(variables_template.format(", ".join(variables)))
+        source.append(variables_formatter([name_map[v] for v in variables]))
 
     # Parameters
     if free_parameters is not None:
@@ -80,7 +128,8 @@ def _generate_model_code(
     if len(parameters) > 0:
         source.append(
             "\n".join(
-                assignment_template.format(k=k, v=v) for k, v in parameters.items()
+                assignment_template.format(k=name_map[k], v=v)
+                for k, v in parameters.items()
             )
         )
 
@@ -96,7 +145,11 @@ def _generate_model_code(
         if expr is None:
             msg = f"Unable to parse fn for derived value '{name}'"
             raise ValueError(msg)
-        source.append(assignment_template.format(k=name, v=sympy_inline_fn(expr)))
+        if sym_subs:
+            expr = cast(sympy.Expr, expr.subs(sym_subs))
+        source.append(
+            assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
+        )
 
     # Reactions
     for name, rxn in model.get_raw_reactions().items():
@@ -113,7 +166,11 @@ def _generate_model_code(
         if expr is None:
             msg = f"Unable to parse fn for reaction value '{name}'"
             raise ValueError(msg)
-        source.append(assignment_template.format(k=name, v=sympy_inline_fn(expr)))
+        if sym_subs:
+            expr = cast(sympy.Expr, expr.subs(sym_subs))
+        source.append(
+            assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
+        )
 
     # Diff eqs
     diff_eqs = {}
@@ -123,8 +180,12 @@ def _generate_model_code(
 
     for variable, stoich in diff_eqs.items():
         expr = stoichiometries_to_sympy(origin=variable, stoichs=stoich)
+        if sym_subs:
+            expr = cast(sympy.Expr, expr.subs(sym_subs))
         source.append(
-            assignment_template.format(k=f"d{variable}dt", v=sympy_inline_fn(expr))
+            assignment_template.format(
+                k=f"d{name_map[variable]}dt", v=sympy_inline_fn(expr)
+            )
         )
 
     # Surrogates
@@ -134,11 +195,143 @@ def _generate_model_code(
 
     # Return
     ret_order = [i for i in variables if i in diff_eqs]
-    if return_formatter is not None:
-        source.append(return_formatter(ret_order))
+    source.append(return_formatter([name_map[v] for v in ret_order]))
+
+    if end is not None:
+        source.append(end)
+
+    # print(source)
+    return "\n".join(source)
+
+
+def _generate_components_code(
+    model: Model,
+    *,
+    sized: bool,
+    model_fn: str,
+    assignment_template: str,
+    sympy_inline_fn: Callable[[sympy.Expr], str],
+    variables_formatter: Callable[[list[str]], str],
+    return_formatter: Callable[[list[str]], str],
+    custom_fns: dict[str, sympy.Expr],
+    imports: list[str] | None = None,
+    end: str | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    source: list[str] = []
+    # Model components
+    variables = model.get_initial_conditions()
+    parameters = model.get_parameter_values()
+
+    # Build sanitized name map for all model component names
+    all_names = (
+        list(variables)
+        + list(parameters)
+        + list(model.get_raw_derived())
+        + list(model.get_raw_reactions())
+        + list(model.get_raw_readouts())
+    )
+    name_map = {n: _to_valid_identifier(n) for n in all_names}
+    sanitized_names = list(name_map.values())
+    if len(sanitized_names) != len(set(sanitized_names)):
+        _LOGGER.warning(
+            "Name sanitization produced duplicate identifiers — "
+            "rename model components to avoid collisions."
+        )
+    # Sympy substitution list: replace symbols with original names by sanitized ones
+    sym_subs = [
+        (sympy.Symbol(orig), sympy.Symbol(san))
+        for orig, san in name_map.items()
+        if orig != san
+    ]
+
+    if imports is not None:
+        source.extend(imports)
+
+    if not sized:
+        source.append(model_fn)
     else:
-        ret = ", ".join(f"d{i}dt" for i in ret_order) if len(diff_eqs) > 0 else "()"
-        source.append(return_template.format(ret))
+        source.append(model_fn.format(n=len(variables)))
+
+    if len(variables) > 0:
+        source.append(variables_formatter([name_map[v] for v in variables]))
+
+    # Parameters
+    if free_parameters is not None:
+        for key in free_parameters:
+            parameters.pop(key)
+    if len(parameters) > 0:
+        source.append(
+            "\n".join(
+                assignment_template.format(k=name_map[k], v=v)
+                for k, v in parameters.items()
+            )
+        )
+
+    returns = []
+
+    # Derived
+    for name, derived in model.get_raw_derived().items():
+        expr = custom_fns.get(name)
+        if expr is None:
+            expr = fn_to_sympy(
+                derived.fn,
+                origin=name,
+                model_args=list_of_symbols(derived.args),
+            )
+        if expr is None:
+            msg = f"Unable to parse fn for derived value '{name}'"
+            raise ValueError(msg)
+        if sym_subs:
+            expr = cast(sympy.Expr, expr.subs(sym_subs))
+        source.append(
+            assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
+        )
+        returns.append(name_map[name])
+
+    # Reactions
+    for name, rxn in model.get_raw_reactions().items():
+        expr = custom_fns.get(name)
+        if expr is None:
+            try:
+                expr = fn_to_sympy(
+                    rxn.fn,
+                    origin=name,
+                    model_args=list_of_symbols(rxn.args),
+                )
+            except KeyError:
+                _LOGGER.warning("Failed to parse %s", name)
+        if expr is None:
+            msg = f"Unable to parse fn for reaction value '{name}'"
+            raise ValueError(msg)
+        if sym_subs:
+            expr = cast(sympy.Expr, expr.subs(sym_subs))
+        source.append(
+            assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
+        )
+        returns.append(name_map[name])
+
+    # Readouts
+    for name, readout in model.get_raw_readouts().items():
+        expr = custom_fns.get(name)
+        if expr is None:
+            expr = fn_to_sympy(
+                readout.fn,
+                origin=name,
+                model_args=list_of_symbols(readout.args),
+            )
+        if expr is None:
+            msg = f"Unable to parse fn for readout value '{name}'"
+            raise ValueError(msg)
+        if sym_subs:
+            expr = cast(sympy.Expr, expr.subs(sym_subs))
+        source.append(
+            assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
+        )
+        returns.append(name_map[name])
+
+    # Return
+    source.append(return_formatter(returns))
 
     if end is not None:
         source.append(end)
@@ -176,7 +369,7 @@ def generate_model_code_py(
             "def model(time: float, variables: Iterable[float]) -> Iterable[float]:"
         )
     else:
-        args = ", ".join(f"{k}: float" for k in free_parameters)
+        args = ", ".join(f"{_to_valid_identifier(k)}: float" for k in free_parameters)
         model_fn = f"def model(time: float, variables: Iterable[float], {args}) -> Iterable[float]:"
 
     return _generate_model_code(
@@ -187,10 +380,60 @@ def generate_model_code_py(
         ],
         sized=False,
         model_fn=model_fn,
-        variables_template="    {} = variables",
         assignment_template="    {k}: float = {v}" if typed else "    {k} = {v}",
         sympy_inline_fn=sympy_to_inline_py,
-        return_template="    return {}",
+        variables_formatter=lambda vs: f"    {', '.join(vs)} = variables",
+        return_formatter=lambda vs: (
+            f"    return {', '.join(f'd{v}dt' for v in vs) or '()'}"
+        ),
+        end=None,
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_py(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+    *,
+    typed: bool = True,
+) -> str:
+    """Transform the model components into a python function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        Python source code of the generated model function
+
+    """
+    if free_parameters is None:
+        model_fn = "def components(time: float, variables: Iterable[float]) -> Iterable[float]:"
+    else:
+        args = ", ".join(f"{_to_valid_identifier(k)}: float" for k in free_parameters)
+        model_fn = f"def components(time: float, variables: Iterable[float], {args}) -> Iterable[float]:"
+
+    return _generate_components_code(
+        model,
+        imports=[
+            "import math\n",
+            "from collections.abc import Iterable\n",
+        ],
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    {k}: float = {v}" if typed else "    {k} = {v}",
+        sympy_inline_fn=sympy_to_inline_py,
+        variables_formatter=lambda vs: f"    {', '.join(vs)} = variables",
+        return_formatter=lambda vs: f"    return {', '.join(vs) or '()'}",
         end=None,
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,
@@ -222,7 +465,7 @@ def generate_model_code_ts(
     if free_parameters is None:
         model_fn = "function model(time: number, variables: number[]) {"
     else:
-        args = ", ".join(f"{k}: number" for k in free_parameters)
+        args = ", ".join(f"{_to_valid_identifier(k)}: number" for k in free_parameters)
         model_fn = f"function model(time: number, variables: number[], {args}) {{"
 
     return _generate_model_code(
@@ -230,10 +473,55 @@ def generate_model_code_ts(
         imports=[],
         sized=False,
         model_fn=model_fn,
-        variables_template="    let [{}] = variables;",
         assignment_template="    let {k}: number = {v};",
         sympy_inline_fn=sympy_to_inline_js,
-        return_template="    return [{}];",
+        variables_formatter=lambda vs: f"    let [{', '.join(vs)}] = variables;",
+        return_formatter=lambda vs: (
+            f"    return [{', '.join(f'd{v}dt' for v in vs) or '()'}];"
+        ),
+        end="};",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_ts(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model components into a TypeScript function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        TypeScript source code of the generated model components function
+
+    """
+    if free_parameters is None:
+        model_fn = "function components(time: number, variables: number[]) {"
+    else:
+        args = ", ".join(f"{_to_valid_identifier(k)}: number" for k in free_parameters)
+        model_fn = f"function components(time: number, variables: number[], {args}) {{"
+
+    return _generate_components_code(
+        model,
+        imports=[],
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    let {k}: number = {v};",
+        sympy_inline_fn=sympy_to_inline_js,
+        variables_formatter=lambda vs: f"    let [{', '.join(vs)}] = variables;",
+        return_formatter=lambda vs: f"    return [{', '.join(vs) or '()'}];",
         end="};",
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,
@@ -265,7 +553,7 @@ def generate_model_code_rs(
     if free_parameters is None:
         model_fn = "fn model(time: f64, variables: &[f64; {n}]) -> [f64; {n}] {{"
     else:
-        args = ", ".join(f"{k}: f64" for k in free_parameters)
+        args = ", ".join(f"{_to_valid_identifier(k)}: f64" for k in free_parameters)
         model_fn = f"fn model(time: f64, variables: &[f64; {{n}}], {args}) -> [f64; {{n}}] {{{{"
 
     return _generate_model_code(
@@ -273,10 +561,61 @@ def generate_model_code_rs(
         imports=None,
         sized=True,
         model_fn=model_fn,
-        variables_template="    let [{}] = *variables;",
         assignment_template="    let {k}: f64 = {v};",
         sympy_inline_fn=sympy_to_inline_rust,
-        return_template="    return [{}]",
+        variables_formatter=lambda vs: f"    let [{', '.join(vs)}] = *variables;",
+        return_formatter=lambda vs: (
+            f"    return [{', '.join(f'd{v}dt' for v in vs) or '()'}]"
+        ),
+        end="}",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_rs(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model components into a Rust function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        Rust source code of the generated model components function
+
+    """
+    n_vars = len(model.get_initial_conditions())
+    n_out = (
+        len(model.get_raw_derived())
+        + len(model.get_raw_reactions())
+        + len(model.get_raw_readouts())
+    )
+    if free_parameters is None:
+        model_fn = f"fn components(time: f64, variables: &[f64; {n_vars}]) -> [f64; {n_out}] {{"
+    else:
+        args = ", ".join(f"{_to_valid_identifier(k)}: f64" for k in free_parameters)
+        model_fn = f"fn components(time: f64, variables: &[f64; {n_vars}], {args}) -> [f64; {n_out}] {{"
+
+    return _generate_components_code(
+        model,
+        imports=None,
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    let {k}: f64 = {v};",
+        sympy_inline_fn=sympy_to_inline_rust,
+        variables_formatter=lambda vs: f"    let [{', '.join(vs)}] = *variables;",
+        return_formatter=lambda vs: f"    return [{', '.join(vs) or '()'}]",
         end="}",
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,
@@ -308,7 +647,7 @@ def generate_model_code_jl(
     if free_parameters is None:
         model_fn = "function model(time, variables)"
     else:
-        args = ", ".join(f"{k}" for k in free_parameters)
+        args = ", ".join(_to_valid_identifier(k) for k in free_parameters)
         model_fn = f"function model(time, variables, {args})"
 
     return _generate_model_code(
@@ -316,10 +655,55 @@ def generate_model_code_jl(
         imports=None,
         sized=False,
         model_fn=model_fn,
-        variables_template="    {} = variables",
         assignment_template="    {k} = {v}",
         sympy_inline_fn=sympy_to_inline_julia,
-        return_template="    return [{}]",
+        variables_formatter=lambda vs: f"    {', '.join(vs)} = variables",
+        return_formatter=lambda vs: (
+            f"    return [{', '.join(f'd{v}dt' for v in vs) or '()'}]"
+        ),
+        end="end",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_jl(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model components into a Julia function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        Julia source code of the generated model components function
+
+    """
+    if free_parameters is None:
+        model_fn = "function components(time, variables)"
+    else:
+        args = ", ".join(_to_valid_identifier(k) for k in free_parameters)
+        model_fn = f"function components(time, variables, {args})"
+
+    return _generate_components_code(
+        model,
+        imports=None,
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    {k} = {v}",
+        sympy_inline_fn=sympy_to_inline_julia,
+        variables_formatter=lambda vs: f"    {', '.join(vs)} = variables",
+        return_formatter=lambda vs: f"    return [{', '.join(vs) or '()'}]",
         end="end",
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,
@@ -354,7 +738,9 @@ def generate_model_code_c(
     if free_parameters is None:
         model_fn = "void model(double t, const double *variables, double *dydt) {"
     else:
-        args_typed = ", ".join(f"double {k}" for k in free_parameters)
+        args_typed = ", ".join(
+            f"double {_to_valid_identifier(k)}" for k in free_parameters
+        )
         model_fn = f"void model(double t, const double *variables, double *dydt, {args_typed}) {{"
 
     return _generate_model_code(
@@ -362,19 +748,69 @@ def generate_model_code_c(
         imports=["#include <math.h>", ""],
         sized=False,
         model_fn=model_fn,
-        variables_template="",  # unused — variables_formatter takes over
         assignment_template="    double {k} = {v};",
         sympy_inline_fn=sympy_to_inline_c,
-        return_template="",  # unused — return_formatter takes over
-        end="}",
-        free_parameters=free_parameters,
-        custom_fns={} if custom_fns is None else custom_fns,
         variables_formatter=lambda vs: "\n".join(
             f"    double {v} = variables[{i}];" for i, v in enumerate(vs)
         ),
-        return_formatter=lambda ret_vars: "\n".join(
-            f"    dydt[{i}] = d{v}dt;" for i, v in enumerate(ret_vars)
+        return_formatter=lambda vs: "\n".join(
+            f"    dydt[{i}] = d{v}dt;" for i, v in enumerate(vs)
         ),
+        end="}",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_c(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model components into a C99 function, inlining the function calls.
+
+    The generated function writes derived values and reaction rates into an
+    output pointer ``out`` rather than returning an array.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        C99 source code of the generated model components function
+
+    """
+    if free_parameters is None:
+        model_fn = "void components(double t, const double *variables, double *out) {"
+    else:
+        args_typed = ", ".join(
+            f"double {_to_valid_identifier(k)}" for k in free_parameters
+        )
+        model_fn = f"void components(double t, const double *variables, double *out, {args_typed}) {{"
+
+    return _generate_components_code(
+        model,
+        imports=["#include <math.h>", ""],
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    double {k} = {v};",
+        sympy_inline_fn=sympy_to_inline_c,
+        variables_formatter=lambda vs: "\n".join(
+            f"    double {v} = variables[{i}];" for i, v in enumerate(vs)
+        ),
+        return_formatter=lambda vs: "\n".join(
+            f"    out[{i}] = {v};" for i, v in enumerate(vs)
+        ),
+        end="}",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
     )
 
 
@@ -403,22 +839,81 @@ def generate_model_code_cpp(
     if free_parameters is None:
         model_fn = "std::array<double, {n}> model(double time, const std::array<double, {n}>& variables) {{"
     else:
-        args_typed = ", ".join(f"double {k}" for k in free_parameters)
+        args_typed = ", ".join(
+            f"double {_to_valid_identifier(k)}" for k in free_parameters
+        )
         model_fn = f"std::array<double, {{n}}> model(double time, const std::array<double, {{n}}>& variables, {args_typed}) {{{{"
 
     return _generate_model_code(
         model,
         sized=True,
         model_fn=model_fn,
-        variables_template="    const auto [{}] = variables;",
         assignment_template="    double {k} = {v};",
         sympy_inline_fn=sympy_to_inline_cxx,
-        return_template="    return {{{}}};",
+        variables_formatter=lambda vs: f"    const auto [{', '.join(vs)}] = variables;",
+        return_formatter=lambda vs: (
+            f"    return {{{', '.join(f'd{v}dt' for v in vs) or '()'}}};"
+        ),
         imports=[
             "#include <array>",
             "#include <cmath>",
             "",
         ],
+        end="}",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_cpp(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model components into a C++ function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        C++ source code of the generated model components function
+
+    """
+    n_vars = len(model.get_initial_conditions())
+    n_out = (
+        len(model.get_raw_derived())
+        + len(model.get_raw_reactions())
+        + len(model.get_raw_readouts())
+    )
+    if free_parameters is None:
+        model_fn = f"std::array<double, {n_out}> components(double time, const std::array<double, {n_vars}>& variables) {{"
+    else:
+        args_typed = ", ".join(
+            f"double {_to_valid_identifier(k)}" for k in free_parameters
+        )
+        model_fn = f"std::array<double, {n_out}> components(double time, const std::array<double, {n_vars}>& variables, {args_typed}) {{"
+
+    return _generate_components_code(
+        model,
+        imports=[
+            "#include <array>",
+            "#include <cmath>",
+            "",
+        ],
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    double {k} = {v};",
+        sympy_inline_fn=sympy_to_inline_cxx,
+        variables_formatter=lambda vs: f"    const auto [{', '.join(vs)}] = variables;",
+        return_formatter=lambda vs: f"    return {{{', '.join(vs) or '()'}}};",
         end="}",
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,
@@ -450,7 +945,7 @@ def generate_model_code_matlab(
     if free_parameters is None:
         model_fn = "function dydt = model(t, variables)"
     else:
-        args = ", ".join(k for k in free_parameters)
+        args = ", ".join(_to_valid_identifier(k) for k in free_parameters)
         model_fn = f"function dydt = model(t, variables, {args})"
 
     return _generate_model_code(
@@ -458,10 +953,59 @@ def generate_model_code_matlab(
         imports=None,
         sized=False,
         model_fn=model_fn,
-        variables_template="    [{}] = num2cell(variables){{:}};",
         assignment_template="    {k} = {v};",
         sympy_inline_fn=sympy_to_inline_matlab,
-        return_template="    dydt = [{}]';",
+        variables_formatter=lambda vs: (
+            f"    [{', '.join(vs)}] = num2cell(variables){{:}};"
+        ),
+        return_formatter=lambda vs: (
+            f"    dydt = [{', '.join(f'd{v}dt' for v in vs) or '()'}]';"
+        ),
+        end="end",
+        free_parameters=free_parameters,
+        custom_fns={} if custom_fns is None else custom_fns,
+    )
+
+
+def generate_model_components_matlab(
+    model: Model,
+    custom_fns: dict[str, sympy.Expr] | None = None,
+    free_parameters: list[str] | None = None,
+) -> str:
+    """Transform the model components into a MATLAB/Octave function, inlining the function calls.
+
+    Parameters
+    ----------
+    model
+        Model to generate code for
+    custom_fns
+        Optional custom sympy expressions to substitute for functions
+    free_parameters
+        Optional list of parameter names to expose as function arguments
+
+    Returns
+    -------
+    str
+        MATLAB/Octave source code of the generated model components function
+
+    """
+    if free_parameters is None:
+        model_fn = "function out = components(t, variables)"
+    else:
+        args = ", ".join(_to_valid_identifier(k) for k in free_parameters)
+        model_fn = f"function out = components(t, variables, {args})"
+
+    return _generate_components_code(
+        model,
+        imports=None,
+        sized=False,
+        model_fn=model_fn,
+        assignment_template="    {k} = {v};",
+        sympy_inline_fn=sympy_to_inline_matlab,
+        variables_formatter=lambda vs: (
+            f"    [{', '.join(vs)}] = num2cell(variables){{:}};"
+        ),
+        return_formatter=lambda vs: f"    out = [{', '.join(vs) or '()'}];",
         end="end",
         free_parameters=free_parameters,
         custom_fns={} if custom_fns is None else custom_fns,

--- a/src/mxlpy/meta/codegen_model.py
+++ b/src/mxlpy/meta/codegen_model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import sympy
 
@@ -204,6 +204,51 @@ def _generate_model_code(
     return "\n".join(source)
 
 
+def _collect_transitive_deps(
+    requested: set[str],
+    derived: dict[str, Any],
+    reactions: dict[str, Any],
+    readouts: dict[str, Any],
+    leaf_names: set[str],
+) -> set[str]:
+    """BFS to find all component names needed to compute requested outputs.
+
+    Parameters
+    ----------
+    requested
+        Names of the desired output components
+    derived
+        All dynamic derived values in the model
+    reactions
+        All reactions in the model
+    readouts
+        All readouts in the model
+    leaf_names
+        Names that are already available (variables, parameters, "time")
+
+    Returns
+    -------
+    set[str]
+        All component names (including intermediates) required to compute
+        every name in ``requested``
+
+    """
+    all_computable: dict[str, Any] = {**derived, **reactions, **readouts}
+    needed: set[str] = set()
+    queue = [n for n in requested if n in all_computable]
+    while queue:
+        name = queue.pop()
+        if name in needed:
+            continue
+        needed.add(name)
+        queue.extend(
+            dep
+            for dep in all_computable[name].args
+            if dep not in leaf_names and dep not in needed and dep in all_computable
+        )
+    return needed
+
+
 def _generate_components_code(
     model: Model,
     *,
@@ -217,28 +262,54 @@ def _generate_components_code(
     imports: list[str] | None = None,
     end: str | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     source: list[str] = []
-    # Model components
     variables = model.get_initial_conditions()
     parameters = model.get_parameter_values()
+    derived_raw = model.get_raw_derived()
+    reactions_raw = model.get_raw_reactions()
+    readouts_raw = model.get_raw_readouts()
+    # _cache is populated as a side-effect of the get_raw_* calls above
+    if (cache_obj := model._cache) is None:  # noqa: SLF001
+        cache_obj = model._create_cache()  # noqa: SLF001
+
+    all_component_names = set(derived_raw) | set(reactions_raw) | set(readouts_raw)
+
+    if outputs is not None:
+        unknown = set(outputs) - all_component_names
+        if unknown:
+            msg = f"Unknown output components: {sorted(unknown)}"
+            raise ValueError(msg)
+        leaf_names = set(variables) | set(parameters) | {"time"}
+        needed = _collect_transitive_deps(
+            set(outputs), derived_raw, reactions_raw, readouts_raw, leaf_names
+        )
+    else:
+        needed = all_component_names
+
+    # Use dyn_order from cache for correct topological ordering of derived + reactions.
+    # dyn_order interleaves derived and reactions so each component appears after
+    # all its dependencies, regardless of insertion order.
+    ordered_dyn = [n for n in cache_obj.dyn_order if n in needed]
+    ordered_readouts = [k for k in readouts_raw if k in needed]
 
     # Build sanitized name map for all model component names
     all_names = (
         list(variables)
         + list(parameters)
-        + list(model.get_raw_derived())
-        + list(model.get_raw_reactions())
-        + list(model.get_raw_readouts())
+        + list(derived_raw)
+        + list(reactions_raw)
+        + list(readouts_raw)
     )
     name_map = {n: _to_valid_identifier(n) for n in all_names}
     sanitized_names = list(name_map.values())
     if len(sanitized_names) != len(set(sanitized_names)):
-        _LOGGER.warning(
+        msg = (
             "Name sanitization produced duplicate identifiers — "
             "rename model components to avoid collisions."
         )
-    # Sympy substitution list: replace symbols with original names by sanitized ones
+        raise ValueError(msg)
     sym_subs = [
         (sympy.Symbol(orig), sympy.Symbol(san))
         for orig, san in name_map.items()
@@ -256,7 +327,6 @@ def _generate_components_code(
     if len(variables) > 0:
         source.append(variables_formatter([name_map[v] for v in variables]))
 
-    # Parameters
     if free_parameters is not None:
         for key in free_parameters:
             parameters.pop(key)
@@ -268,51 +338,44 @@ def _generate_components_code(
             )
         )
 
-    returns = []
-
-    # Derived
-    for name, derived in model.get_raw_derived().items():
-        expr = custom_fns.get(name)
-        if expr is None:
-            expr = fn_to_sympy(
-                derived.fn,
-                origin=name,
-                model_args=list_of_symbols(derived.args),
-            )
-        if expr is None:
-            msg = f"Unable to parse fn for derived value '{name}'"
-            raise ValueError(msg)
-        if sym_subs:
-            expr = cast(sympy.Expr, expr.subs(sym_subs))
-        source.append(
-            assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
-        )
-        returns.append(name_map[name])
-
-    # Reactions
-    for name, rxn in model.get_raw_reactions().items():
-        expr = custom_fns.get(name)
-        if expr is None:
-            try:
+    # Derived and reactions in correct topological order
+    for name in ordered_dyn:
+        if name in derived_raw:
+            component = derived_raw[name]
+            expr = custom_fns.get(name)
+            if expr is None:
                 expr = fn_to_sympy(
-                    rxn.fn,
+                    component.fn,
                     origin=name,
-                    model_args=list_of_symbols(rxn.args),
+                    model_args=list_of_symbols(component.args),
                 )
-            except KeyError:
-                _LOGGER.warning("Failed to parse %s", name)
-        if expr is None:
-            msg = f"Unable to parse fn for reaction value '{name}'"
-            raise ValueError(msg)
+            if expr is None:
+                msg = f"Unable to parse fn for derived value '{name}'"
+                raise ValueError(msg)
+        else:
+            component = reactions_raw[name]
+            expr = custom_fns.get(name)
+            if expr is None:
+                try:
+                    expr = fn_to_sympy(
+                        component.fn,
+                        origin=name,
+                        model_args=list_of_symbols(component.args),
+                    )
+                except KeyError:
+                    _LOGGER.warning("Failed to parse %s", name)
+            if expr is None:
+                msg = f"Unable to parse fn for reaction value '{name}'"
+                raise ValueError(msg)
         if sym_subs:
             expr = cast(sympy.Expr, expr.subs(sym_subs))
         source.append(
             assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
         )
-        returns.append(name_map[name])
 
-    # Readouts
-    for name, readout in model.get_raw_readouts().items():
+    # Readouts always come after derived + reactions
+    for name in ordered_readouts:
+        readout = readouts_raw[name]
         expr = custom_fns.get(name)
         if expr is None:
             expr = fn_to_sympy(
@@ -328,15 +391,19 @@ def _generate_components_code(
         source.append(
             assignment_template.format(k=name_map[name], v=sympy_inline_fn(expr))
         )
-        returns.append(name_map[name])
 
-    # Return
+    # Return only the explicitly requested outputs (in requested order),
+    # or everything when outputs is None (maintaining emission order).
+    if outputs is not None:
+        returns = [name_map[n] for n in outputs]
+    else:
+        returns = [name_map[n] for n in ordered_dyn + ordered_readouts]
+
     source.append(return_formatter(returns))
 
     if end is not None:
         source.append(end)
 
-    # print(source)
     return "\n".join(source)
 
 
@@ -396,6 +463,7 @@ def generate_model_components_py(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
     *,
     typed: bool = True,
 ) -> str:
@@ -409,6 +477,9 @@ def generate_model_components_py(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -436,6 +507,7 @@ def generate_model_components_py(
         return_formatter=lambda vs: f"    return {', '.join(vs) or '()'}",
         end=None,
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )
 
@@ -489,6 +561,7 @@ def generate_model_components_ts(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     """Transform the model components into a TypeScript function, inlining the function calls.
 
@@ -500,6 +573,9 @@ def generate_model_components_ts(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -524,6 +600,7 @@ def generate_model_components_ts(
         return_formatter=lambda vs: f"    return [{', '.join(vs) or '()'}];",
         end="};",
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )
 
@@ -577,6 +654,7 @@ def generate_model_components_rs(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     """Transform the model components into a Rust function, inlining the function calls.
 
@@ -588,6 +666,9 @@ def generate_model_components_rs(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -597,9 +678,13 @@ def generate_model_components_rs(
     """
     n_vars = len(model.get_initial_conditions())
     n_out = (
-        len(model.get_raw_derived())
-        + len(model.get_raw_reactions())
-        + len(model.get_raw_readouts())
+        len(outputs)
+        if outputs is not None
+        else (
+            len(model.get_raw_derived())
+            + len(model.get_raw_reactions())
+            + len(model.get_raw_readouts())
+        )
     )
     if free_parameters is None:
         model_fn = f"fn components(time: f64, variables: &[f64; {n_vars}]) -> [f64; {n_out}] {{"
@@ -618,6 +703,7 @@ def generate_model_components_rs(
         return_formatter=lambda vs: f"    return [{', '.join(vs) or '()'}]",
         end="}",
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )
 
@@ -671,6 +757,7 @@ def generate_model_components_jl(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     """Transform the model components into a Julia function, inlining the function calls.
 
@@ -682,6 +769,9 @@ def generate_model_components_jl(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -706,6 +796,7 @@ def generate_model_components_jl(
         return_formatter=lambda vs: f"    return [{', '.join(vs) or '()'}]",
         end="end",
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )
 
@@ -766,6 +857,7 @@ def generate_model_components_c(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     """Transform the model components into a C99 function, inlining the function calls.
 
@@ -780,6 +872,9 @@ def generate_model_components_c(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -810,6 +905,7 @@ def generate_model_components_c(
         ),
         end="}",
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )
 
@@ -869,6 +965,7 @@ def generate_model_components_cpp(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     """Transform the model components into a C++ function, inlining the function calls.
 
@@ -880,6 +977,9 @@ def generate_model_components_cpp(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -889,9 +989,13 @@ def generate_model_components_cpp(
     """
     n_vars = len(model.get_initial_conditions())
     n_out = (
-        len(model.get_raw_derived())
-        + len(model.get_raw_reactions())
-        + len(model.get_raw_readouts())
+        len(outputs)
+        if outputs is not None
+        else (
+            len(model.get_raw_derived())
+            + len(model.get_raw_reactions())
+            + len(model.get_raw_readouts())
+        )
     )
     if free_parameters is None:
         model_fn = f"std::array<double, {n_out}> components(double time, const std::array<double, {n_vars}>& variables) {{"
@@ -916,6 +1020,7 @@ def generate_model_components_cpp(
         return_formatter=lambda vs: f"    return {{{', '.join(vs) or '()'}}};",
         end="}",
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )
 
@@ -971,6 +1076,7 @@ def generate_model_components_matlab(
     model: Model,
     custom_fns: dict[str, sympy.Expr] | None = None,
     free_parameters: list[str] | None = None,
+    outputs: list[str] | None = None,
 ) -> str:
     """Transform the model components into a MATLAB/Octave function, inlining the function calls.
 
@@ -982,6 +1088,9 @@ def generate_model_components_matlab(
         Optional custom sympy expressions to substitute for functions
     free_parameters
         Optional list of parameter names to expose as function arguments
+    outputs
+        Optional subset of component names to emit. All transitive dependencies
+        are included automatically. When None all components are emitted.
 
     Returns
     -------
@@ -1008,5 +1117,6 @@ def generate_model_components_matlab(
         return_formatter=lambda vs: f"    out = [{', '.join(vs) or '()'}];",
         end="end",
         free_parameters=free_parameters,
+        outputs=outputs,
         custom_fns={} if custom_fns is None else custom_fns,
     )

--- a/src/mxlpy/meta/source_tools.py
+++ b/src/mxlpy/meta/source_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import builtins
 import importlib
 import inspect
 import logging
@@ -20,6 +21,8 @@ from wadler_lindig import pformat
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from sympy.core.function import Function
+
 __all__ = [
     "Context",
     "KNOWN_CONSTANTS",
@@ -32,6 +35,63 @@ __all__ = [
 
 _LOGGER = logging.getLogger(__name__)
 PARSE_ERROR = sympy.Symbol("ERROR")
+
+
+def _sympy_log10(x: sympy.Expr) -> Function:
+    return sympy.log(x, 10)  # type: ignore
+
+
+def _sympy_log2(x: sympy.Expr) -> Function:
+    return sympy.log(x, 2)  # type: ignore
+
+
+def _sympy_log1p(x: sympy.Expr) -> sympy.Expr:
+    return sympy.log(1 + x)  # type: ignore
+
+
+def _sympy_exp2(x: sympy.Expr) -> sympy.Expr:
+    return sympy.Pow(2, x)  # type: ignore
+
+
+def _sympy_expm1(x: sympy.Expr) -> sympy.Expr:
+    return sympy.exp(x) - 1  # type: ignore
+
+
+def _sympy_degrees(x: sympy.Expr) -> sympy.Expr:
+    return x * 180 / sympy.pi  # type: ignore
+
+
+def _sympy_hypot(x: sympy.Expr, y: sympy.Expr) -> sympy.Expr:
+    return sympy.sqrt(x**2 + y**2)  # type: ignore
+
+
+def _sympy_isqrt(x: sympy.Expr) -> sympy.Expr:
+    return sympy.floor(sympy.sqrt(x))
+
+
+def _sympy_ldexp(x: sympy.Expr, i: sympy.Expr) -> sympy.Expr:
+    return x * sympy.Pow(2, i)  # type: ignore
+
+
+def _sympy_copysign(x: sympy.Expr, y: sympy.Expr) -> sympy.Expr:
+    return sympy.Abs(x) * sympy.sign(y)  # type: ignore
+
+
+def _sympy_perm(n: sympy.Expr, k: sympy.Expr) -> sympy.Expr:
+    return sympy.FallingFactorial(n, k)  # type: ignore
+
+
+def _sympy_square(x: sympy.Expr) -> sympy.Expr:
+    return sympy.Pow(x, 2)
+
+
+def _sympy_subtract(x: sympy.Expr, y: sympy.Expr) -> sympy.Expr:
+    return x - y  # type: ignore
+
+
+def _sympy_true_divide(x: sympy.Expr, y: sympy.Expr) -> sympy.Expr:
+    return x / y  # type: ignore
+
 
 KNOWN_CONSTANTS: dict[float, sympy.Float] = {
     math.e: sympy.E,
@@ -64,41 +124,41 @@ KNOWN_FNS: dict[Callable, sympy.Expr] = {
     math.atanh: sympy.atanh,
     math.cbrt: sympy.cbrt,
     math.ceil: sympy.ceiling,
-    # math.comb: sympy.comb,
-    # math.copysign: sympy.copysign,
+    math.comb: sympy.binomial,
+    math.copysign: _sympy_copysign,
     math.cos: sympy.cos,
     math.cosh: sympy.cosh,
-    # math.degrees: sympy.degrees,
-    # math.dist: sympy.dist,
+    math.degrees: _sympy_degrees,
+    # math.dist: no scalar sympy equivalent
     math.erf: sympy.erf,
     math.erfc: sympy.erfc,
     math.exp: sympy.exp,
-    # math.exp2: sympy.exp2,
-    # math.expm1: sympy.expm1,
-    # math.fabs: sympy.fabs,
+    math.exp2: _sympy_exp2,
+    math.expm1: _sympy_expm1,
+    math.fabs: sympy.Abs,
     math.factorial: sympy.factorial,
     math.floor: sympy.floor,
-    # math.fmod: sympy.fmod,
-    # math.frexp: sympy.frexp,
-    # math.fsum: sympy.fsum,
+    math.fmod: sympy.Mod,
+    # math.frexp: returns tuple, no sympy equivalent
+    # math.fsum: takes iterable, no sympy equivalent
     math.gamma: sympy.gamma,
     math.gcd: sympy.gcd,
-    # math.hypot: sympy.hypot,
-    # math.isclose: sympy.isclose,
-    # math.isfinite: sympy.isfinite,
-    # math.isinf: sympy.isinf,
-    # math.isnan: sympy.isnan,
-    # math.isqrt: sympy.isqrt,
+    math.hypot: _sympy_hypot,
+    # math.isclose: boolean, no sympy equivalent
+    # math.isfinite: boolean, no sympy equivalent
+    # math.isinf: boolean, no sympy equivalent
+    # math.isnan: boolean, no sympy equivalent
+    math.isqrt: _sympy_isqrt,
     math.lcm: sympy.lcm,
-    # math.ldexp: sympy.ldexp,
-    # math.lgamma: sympy.lgamma,
+    math.ldexp: _sympy_ldexp,
+    math.lgamma: sympy.loggamma,
     math.log: sympy.log,
-    # math.log10: sympy.log10,
-    # math.log1p: sympy.log1p,
-    # math.log2: sympy.log2,
-    # math.modf: sympy.modf,
-    # math.nextafter: sympy.nextafter,
-    # math.perm: sympy.perm,
+    math.log10: _sympy_log10,
+    math.log1p: _sympy_log1p,
+    math.log2: _sympy_log2,
+    # math.modf: returns tuple, no sympy equivalent
+    # math.nextafter: float-specific, no sympy equivalent
+    math.perm: _sympy_perm,
     math.pow: sympy.Pow,
     math.prod: sympy.prod,
     math.radians: sympy.rad,
@@ -106,11 +166,11 @@ KNOWN_FNS: dict[Callable, sympy.Expr] = {
     math.sin: sympy.sin,
     math.sinh: sympy.sinh,
     math.sqrt: sympy.sqrt,
-    # math.sumprod: sympy.sumprod,
+    # math.sumprod: takes iterables, no sympy equivalent
     math.tan: sympy.tan,
     math.tanh: sympy.tanh,
     math.trunc: sympy.trunc,
-    # math.ulp: sympy.ulp,
+    # math.ulp: float-specific, no sympy equivalent
     # numpy
     np.abs: sympy.Abs,
     np.acos: sympy.acos,
@@ -145,6 +205,7 @@ KNOWN_FNS: dict[Callable, sympy.Expr] = {
     np.less: sympy.LessThan,
     np.less_equal: sympy.Le,
     np.log: sympy.log,
+    np.log10: _sympy_log10,
     np.maximum: sympy.maximum,
     np.minimum: sympy.minimum,
     np.mod: sympy.Mod,
@@ -154,13 +215,13 @@ KNOWN_FNS: dict[Callable, sympy.Expr] = {
     np.sin: sympy.sin,
     np.sinh: sympy.sinh,
     np.sqrt: sympy.sqrt,
-    # np.square: sympy.square,
-    # np.subtract: sympy., # Add(x, -1 * y)
+    np.square: _sympy_square,
+    np.subtract: _sympy_subtract,
     np.tan: sympy.tan,
     np.tanh: sympy.tanh,
-    # np.true_divide: sympy.true_divide,
+    np.true_divide: _sympy_true_divide,
     np.trunc: sympy.trunc,
-    # np.vecdot: sympy.vecdot,
+    # np.vecdot: vector operation, no scalar sympy equivalent
 }
 
 
@@ -710,6 +771,7 @@ def _handle_call(node: ast.Call, ctx: Context) -> sympy.Expr | None:
             fn_name = str(id)
             fns = (
                 dict(inspect.getmembers(ctx.parent_module, predicate=callable))
+                | dict(inspect.getmembers(builtins, predicate=callable))
                 | ctx.fns
             )
             py_fn = fns.get(fn_name)
@@ -745,7 +807,10 @@ def _handle_call(node: ast.Call, ctx: Context) -> sympy.Expr | None:
         return None
 
     if (fn := KNOWN_FNS.get(py_fn)) is not None:
-        return sympy.Float(fn(*model_args))  # type: ignore
+        result = fn(*model_args)  # type: ignore
+        if isinstance(result, (int, float)):
+            return sympy.Float(result)
+        return cast(sympy.Expr, result)
 
     return fn_to_sympy(
         py_fn,

--- a/tests/codegen/test_generate_components_outputs.py
+++ b/tests/codegen/test_generate_components_outputs.py
@@ -1,0 +1,215 @@
+"""Tests for generate_model_components_py with an explicit outputs subset."""
+
+from __future__ import annotations
+
+import pytest
+
+from mxlpy import Model, fns
+from mxlpy.meta.codegen_model import generate_model_components_py
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _model_1v_1p_1d_1r() -> Model:
+    """v1, p1 → d1 = v1+p1 → r1 = d1*v1."""
+    return (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_parameter("p1", 1.0)
+        .add_derived("d1", fn=fns.add, args=["v1", "p1"])
+        .add_reaction("r1", fn=fns.mass_action_1s, args=["v1", "d1"], stoichiometry={"v1": -1.0})
+    )
+
+
+def _model_2d_1r() -> Model:
+    """v1 → d1 → d2 → r1.  Two-level derived chain."""
+    return (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_derived("d1", fn=fns.constant, args=["v1"])
+        .add_derived("d2", fn=fns.constant, args=["d1"])
+        .add_reaction("r1", fn=fns.mass_action_1s, args=["v1", "d2"], stoichiometry={"v1": -1.0})
+    )
+
+
+def _model_with_readout() -> Model:
+    """v1, v2 → r1, r2; readout ro1 depends on r1 and r2."""
+
+    def ratio(a: float, b: float) -> float:
+        return a / b
+
+    return (
+        Model()
+        .add_variables({"v1": 1.0, "v2": 2.0})
+        .add_parameter("k", 0.1)
+        .add_reaction("r1", fn=fns.mass_action_1s, args=["k", "v1"], stoichiometry={"v1": -1.0})
+        .add_reaction("r2", fn=fns.mass_action_1s, args=["k", "v2"], stoichiometry={"v2": -1.0})
+        .add_readout("ro1", fn=ratio, args=["r1", "r2"])
+    )
+
+
+# ---------------------------------------------------------------------------
+# outputs=None (default) — baseline, all components emitted
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_none_emits_all_components() -> None:
+    code = generate_model_components_py(_model_1v_1p_1d_1r(), outputs=None)
+    lines = code.split("\n")
+    assert "    d1: float = p1 + v1" in lines
+    assert "    r1: float = d1*v1" in lines
+    assert "    return d1, r1" in lines
+
+
+# ---------------------------------------------------------------------------
+# Single output — reaction only, no intermediate deps
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_single_reaction_no_intermediate_deps() -> None:
+    """r1 depends only on k and v1 (leaves) so nothing extra is emitted."""
+    m = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_parameter("k", 0.5)
+        .add_reaction("r1", fn=fns.mass_action_1s, args=["k", "v1"], stoichiometry={"v1": -1.0})
+    )
+    lines = generate_model_components_py(m, outputs=["r1"]).split("\n")
+    assert "    r1: float = k*v1" in lines
+    assert "    return r1" in lines
+
+
+# ---------------------------------------------------------------------------
+# Single output — derived value
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_single_derived() -> None:
+    lines = generate_model_components_py(_model_1v_1p_1d_1r(), outputs=["d1"]).split("\n")
+    assert "    d1: float = p1 + v1" in lines
+    assert "    return d1" in lines
+    # r1 must NOT be emitted
+    assert not any("r1" in ln for ln in lines)
+
+
+# ---------------------------------------------------------------------------
+# Transitive dependency: reaction depends on a derived value
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_reaction_pulls_in_derived_dep() -> None:
+    """Requesting r1 must also emit d1 as an intermediate."""
+    lines = generate_model_components_py(_model_1v_1p_1d_1r(), outputs=["r1"]).split("\n")
+    # d1 is a dep — it must appear before r1
+    assert "    d1: float = p1 + v1" in lines
+    assert "    r1: float = d1*v1" in lines
+    # only r1 in the return
+    assert "    return r1" in lines
+    d1_idx = next(i for i, ln in enumerate(lines) if "d1: float" in ln)
+    r1_idx = next(i for i, ln in enumerate(lines) if "r1: float" in ln)
+    assert d1_idx < r1_idx
+
+
+# ---------------------------------------------------------------------------
+# Transitive dependency: two-level derived chain
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_transitive_two_level_derived_chain() -> None:
+    """Requesting r1 from d1→d2→r1 chain must emit d1 and d2 in order."""
+    lines = generate_model_components_py(_model_2d_1r(), outputs=["r1"]).split("\n")
+    assert any("d1" in ln for ln in lines)
+    assert any("d2" in ln for ln in lines)
+    assert "    return r1" in lines
+    d1_idx = next(i for i, ln in enumerate(lines) if "d1: float" in ln)
+    d2_idx = next(i for i, ln in enumerate(lines) if "d2: float" in ln)
+    r1_idx = next(i for i, ln in enumerate(lines) if "r1: float" in ln)
+    assert d1_idx < d2_idx < r1_idx
+
+
+def test_outputs_intermediate_dep_not_in_return() -> None:
+    """d1 and d2 are intermediates for r1 — they must not appear in the return."""
+    lines = generate_model_components_py(_model_2d_1r(), outputs=["r1"]).split("\n")
+    return_line = next(ln for ln in lines if ln.strip().startswith("return"))
+    assert "d1" not in return_line
+    assert "d2" not in return_line
+    assert "r1" in return_line
+
+
+# ---------------------------------------------------------------------------
+# Readout with reaction dependencies
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_readout_pulls_in_reaction_deps() -> None:
+    """Requesting ro1 must emit r1 and r2 as intermediates."""
+    lines = generate_model_components_py(_model_with_readout(), outputs=["ro1"]).split("\n")
+    assert any("r1: float" in ln for ln in lines)
+    assert any("r2: float" in ln for ln in lines)
+    assert any("ro1: float" in ln for ln in lines)
+    assert "    return ro1" in lines
+    # reactions come before readout
+    r1_idx = next(i for i, ln in enumerate(lines) if "r1: float" in ln)
+    ro1_idx = next(i for i, ln in enumerate(lines) if "ro1: float" in ln)
+    assert r1_idx < ro1_idx
+
+
+# ---------------------------------------------------------------------------
+# Multiple outputs
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_multiple_returns_in_requested_order() -> None:
+    lines = generate_model_components_py(_model_1v_1p_1d_1r(), outputs=["d1", "r1"]).split("\n")
+    assert "    return d1, r1" in lines
+
+
+def test_outputs_multiple_reversed_order() -> None:
+    """Return order follows the outputs list, not emission order."""
+    lines = generate_model_components_py(_model_1v_1p_1d_1r(), outputs=["r1", "d1"]).split("\n")
+    assert "    return r1, d1" in lines
+
+
+# ---------------------------------------------------------------------------
+# Subset omits unrelated components
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_unrelated_components_not_emitted() -> None:
+    """Requesting only d1 must not emit r1 at all."""
+    m = _model_1v_1p_1d_1r()
+    lines = generate_model_components_py(m, outputs=["d1"]).split("\n")
+    assert not any("r1" in ln for ln in lines)
+
+
+def test_outputs_independent_reactions_not_emitted() -> None:
+    """Two independent reactions; requesting one omits the other."""
+    m = (
+        Model()
+        .add_variables({"v1": 1.0, "v2": 2.0})
+        .add_parameter("k", 0.1)
+        .add_reaction("r1", fn=fns.mass_action_1s, args=["k", "v1"], stoichiometry={"v1": -1.0})
+        .add_reaction("r2", fn=fns.mass_action_1s, args=["k", "v2"], stoichiometry={"v2": -1.0})
+    )
+    lines = generate_model_components_py(m, outputs=["r1"]).split("\n")
+    assert any("r1: float" in ln for ln in lines)
+    assert not any("r2: float" in ln for ln in lines)
+    assert "    return r1" in lines
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_outputs_unknown_name_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown output components"):
+        generate_model_components_py(_model_1v_1p_1d_1r(), outputs=["nonexistent"])
+
+
+def test_outputs_partially_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown output components"):
+        generate_model_components_py(_model_1v_1p_1d_1r(), outputs=["d1", "ghost"])

--- a/tests/codegen/test_name_sanitization.py
+++ b/tests/codegen/test_name_sanitization.py
@@ -1,0 +1,147 @@
+"""Tests for name sanitization in code generation.
+
+Model component names may contain characters that are invalid identifiers
+in target languages (e.g. hyphens, spaces, dots). The generators must
+sanitize all names before emitting code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mxlpy import Model, fns
+from mxlpy.meta import (
+    generate_model_code_jl,
+    generate_model_code_py,
+    generate_model_code_rs,
+    generate_model_code_ts,
+)
+from mxlpy.meta.codegen_model import (
+    _to_valid_identifier,
+    generate_model_code_c,
+    generate_model_code_cpp,
+    generate_model_code_matlab,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _to_valid_identifier
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("my-var", "my_var"),
+        ("my.var", "my_var"),
+        ("my var", "my_var"),
+        ("1abc", "_1abc"),
+        ("a+b", "a_b"),
+        ("", "_"),
+        ("valid_name", "valid_name"),
+        ("CamelCase", "CamelCase"),
+        ("__private", "__private"),
+        ("a[0]", "a_0_"),
+        ("k.1", "k_1"),
+    ],
+)
+def test_to_valid_identifier(name: str, expected: str) -> None:
+    assert _to_valid_identifier(name) == expected
+
+
+# ---------------------------------------------------------------------------
+# Integration: model with invalid names generates valid code
+# ---------------------------------------------------------------------------
+
+
+def _model_with_invalid_names() -> Model:
+    """Model using hyphens and dots in component names."""
+    return (
+        Model()
+        .add_variable("my-var", 1.0)
+        .add_parameter("k.1", 2.0)
+        .add_derived(
+            "d-1",
+            fn=fns.add,
+            args=["my-var", "k.1"],
+        )
+        .add_reaction(
+            "r-1",
+            fn=fns.mass_action_1s,
+            args=["my-var", "d-1"],
+            stoichiometry={"my-var": -1.0},
+        )
+    )
+
+
+def test_name_sanitization_ts() -> None:
+    lines = generate_model_code_ts(_model_with_invalid_names()).split("\n")
+    assert lines == [
+        "function model(time: number, variables: number[]) {",
+        "    let [my_var] = variables;",
+        "    let k_1: number = 2.0;",
+        "    let d_1: number = k_1 + my_var;",
+        "    let r_1: number = d_1*my_var;",
+        "    let dmy_vardt: number = -r_1;",
+        "    return [dmy_vardt];",
+        "};",
+    ]
+
+
+def test_name_sanitization_py() -> None:
+    code = generate_model_code_py(_model_with_invalid_names())
+    assert "my_var" in code
+    assert "k_1" in code
+    assert "d_1" in code
+    assert "r_1" in code
+    assert "dmy_vardt" in code
+    assert "my-var" not in code
+    assert "k.1" not in code
+    assert "d-1" not in code
+    assert "r-1" not in code
+
+
+def test_name_sanitization_c() -> None:
+    code = generate_model_code_c(_model_with_invalid_names())
+    assert "my_var" in code
+    assert "k_1" in code
+    assert "d_1" in code
+    assert "r_1" in code
+    assert "dmy_vardt" in code
+    # original invalid names must not appear
+    assert "my-var" not in code
+    assert "k.1" not in code
+    assert "d-1" not in code
+    assert "r-1" not in code
+
+
+def test_name_sanitization_cpp() -> None:
+    code = generate_model_code_cpp(_model_with_invalid_names())
+    assert "my_var" in code
+    assert "k_1" in code
+    assert "dmy_vardt" in code
+    assert "my-var" not in code
+
+
+def test_name_sanitization_rs() -> None:
+    code = generate_model_code_rs(_model_with_invalid_names())
+    assert "my_var" in code
+    assert "k_1" in code
+    assert "dmy_vardt" in code
+    assert "my-var" not in code
+
+
+def test_name_sanitization_jl() -> None:
+    code = generate_model_code_jl(_model_with_invalid_names())
+    assert "my_var" in code
+    assert "k_1" in code
+    assert "dmy_vardt" in code
+    assert "my-var" not in code
+
+
+def test_name_sanitization_matlab() -> None:
+    code = generate_model_code_matlab(_model_with_invalid_names())
+    assert "my_var" in code
+    assert "k_1" in code
+    assert "dmy_vardt" in code
+    assert "my-var" not in code

--- a/tests/fn_to_sympy/test_common_libs.py
+++ b/tests/fn_to_sympy/test_common_libs.py
@@ -31,8 +31,8 @@ def test_math_import_attr_l1() -> None:
 
 
 def test_math_import_fn_l0() -> None:
-    assert source_tools.fn_to_sympy(exp_direct, "test") == 1.0
+    assert float(source_tools.fn_to_sympy(exp_direct, "test")) == 1.0  # pyright: ignore[reportArgumentType]
 
 
 def test_math_import_fn_l1() -> None:
-    assert source_tools.fn_to_sympy(exp_library_call, "test") == 1.0
+    assert float(source_tools.fn_to_sympy(exp_library_call, "test")) == 1.0  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
## Summary

- Add `generate_model_components_*` functions for all 7 target languages (Python, TypeScript, Rust, Julia, C99, C++, MATLAB/Octave) that emit derived values, reactions, and readouts as a single callable instead of ODE-only code.
- Introduce `_to_valid_identifier` (C99 rules) applied throughout codegen so model component names with special characters are safely mapped to valid identifiers in all targets; topological ordering now uses `dyn_order` from the model cache, fixing a latent bug with insertion-order emission.
- Add `outputs: list[str] | None` parameter to all components functions: when given, only the requested components and their transitive dependencies are emitted, with the return containing exactly the requested names in order. Also expand `KNOWN_FNS` in `source_tools.py` with previously missing `math`/`numpy` functions.

## Test plan

- `uv run pytest tests/codegen/ --disable-warnings` — 97 codegen tests including 13 new tests covering subset filtering, transitive dep resolution, readout deps, return ordering, and error handling.
- Verify generated Python code executes correctly for a model with derived values that depend on reactions.
- Check that `outputs=["nonexistent"]` raises `ValueError`.