### PR TITLE
fix: improve error messages across the codebase for actionability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.38.0"
+version = "0.39.0"
 
 [project.optional-dependencies]
 jax = [

--- a/src/mxlpy/fit/residuals.py
+++ b/src/mxlpy/fit/residuals.py
@@ -133,7 +133,7 @@ def protocol_time_course_residual(
         model.update_variable(p, updates[p])
 
     if (protocol := settings.protocol) is None:
-        msg = "No protocol supplied"
+        msg = "protocol_time_course_residual requires a protocol but settings.protocol is None — set settings.protocol to a DataFrame before fitting"
         raise ValueError(msg)
 
     res = (

--- a/src/mxlpy/linear_label_map.py
+++ b/src/mxlpy/linear_label_map.py
@@ -54,7 +54,7 @@ def _generate_isotope_labels(base_name: str, num_labels: int) -> list[str]:
     """
     if num_labels > 0:
         return [f"{base_name}__{i}" for i in range(num_labels)]
-    msg = f"Compound {base_name} must have labels"
+    msg = f"Compound '{base_name}' requires at least 1 label position, got {num_labels}"
     raise ValueError(msg)
 
 
@@ -87,7 +87,8 @@ def _unpack_stoichiometries(
     products = {}
     for k, v in stoichiometries.items():
         if isinstance(v, Derived):
-            raise NotImplementedError
+            msg = f"Derived stoichiometry for species '{k}' is not supported in linear label maps — use a plain float coefficient instead"
+            raise NotImplementedError(msg)
 
         if v < 0:
             substrates[k] = int(-v)
@@ -191,7 +192,7 @@ def _add_label_influx_or_efflux(
 
     # Broken labelmap
     if (diff := len(labelmap) - len(substrates)) < 0:
-        msg = f"Labelmap 'missing' {abs(diff)} label(s)"
+        msg = f"Labelmap has {len(labelmap)} entries but reaction needs {len(substrates)} — missing {abs(diff)} label(s)"
         raise ValueError(msg)
     return substrates, products
 

--- a/src/mxlpy/meta/codegen_mxlpy_raw.py
+++ b/src/mxlpy/meta/codegen_mxlpy_raw.py
@@ -37,12 +37,12 @@ def _fn_to_source(fn: Callable, fn_name: str, args: list[str]) -> str:
         raw = inspect.getsource(fn)
     except OSError:
         if _dill is None:
-            msg = f"Cannot retrieve source for '{fn_name}': dill not installed"
+            msg = f"Cannot retrieve source for '{fn_name}': inspect.getsource() failed and dill is not installed — install dill ('pip install dill') to support dynamically-defined functions"
             raise ValueError(msg) from None
         try:
             raw = _dill.source.getsource(fn)
         except OSError as exc:
-            msg = f"Cannot retrieve source for '{fn_name}'"
+            msg = f"Cannot retrieve source for '{fn_name}': both inspect.getsource() and dill.source.getsource() failed — the function may be defined in a REPL or via exec()"
             raise ValueError(msg) from exc
 
     source = textwrap.dedent(raw)
@@ -61,7 +61,7 @@ def _lambda_to_def(source: str, fn_name: str, args: list[str]) -> str:
         None,
     )
     if lambda_node is None:
-        msg = f"Could not find lambda in source for '{fn_name}'"
+        msg = f"Could not find a lambda expression in the source of '{fn_name}' — the source may belong to a different statement or the lambda is not at module scope"
         raise ValueError(msg)
 
     # orig_params = [arg.arg for arg in lambda_node.args.args]

--- a/src/mxlpy/meta/codegen_mxlweb.py
+++ b/src/mxlpy/meta/codegen_mxlweb.py
@@ -230,7 +230,7 @@ def _fn_to_mxlweb(
     """
     expr = fn_to_sympy(fn, origin=name, model_args=list_of_symbols(args))  # type: ignore[arg-type]
     if expr is None:
-        msg = f"Cannot convert fn for '{name}' to sympy"
+        msg = f"Cannot convert '{name}' to a sympy expression — the function may use unsupported constructs (closures, side effects, non-arithmetic operations)"
         raise ValueError(msg)
     if sym_subs:
         expr = cast(sympy.Expr, expr.subs(sym_subs))

--- a/src/mxlpy/meta/source_tools.py
+++ b/src/mxlpy/meta/source_tools.py
@@ -342,7 +342,7 @@ def get_fn_ast(fn: Callable) -> ast.FunctionDef:
     """
     tree = ast.parse(textwrap.dedent(get_fn_source(fn)))
     if not isinstance(fn_def := tree.body[0], ast.FunctionDef):
-        msg = "Not a function"
+        msg = f"Expected a function definition but got {type(fn_def).__name__} — pass a named function, not a class or bare expression"
         raise TypeError(msg)
     return fn_def
 
@@ -491,7 +491,7 @@ def _handle_fn_body_outputs(
                             ctx.symbols[target.id] = expr
             else:
                 if not isinstance(target := node.targets[0], ast.Name):
-                    msg = "Only single variable assignments are supported"
+                    msg = f"Only simple 'x = expr' assignments are supported in rate functions — got {type(target).__name__} assignment target at line {node.lineno}"
                     raise TypeError(msg)
                 value = _handle_expr(node.value, ctx)
                 if value is None:
@@ -572,7 +572,7 @@ def _handle_fn_body(body: list[ast.stmt], ctx: Context) -> sympy.Expr | None:
 
         elif isinstance(node, ast.Return):
             if (value := node.value) is None:
-                msg = "Return value cannot be None"
+                msg = "Bare 'return' with no value is not supported in rate functions — return a float expression"
                 raise ValueError(msg)
 
             expr = _handle_expr(value, ctx)
@@ -604,7 +604,7 @@ def _handle_fn_body(body: list[ast.stmt], ctx: Context) -> sympy.Expr | None:
             else:
                 # Regular single assignment
                 if not isinstance(target := node.targets[0], ast.Name):
-                    msg = "Only single variable assignments are supported"
+                    msg = f"Only simple 'x = expr' assignments are supported in rate functions — got {type(target).__name__} assignment target at line {node.lineno}"
                     raise TypeError(msg)
                 target_name = target.id
                 value = _handle_expr(node.value, ctx)
@@ -645,7 +645,7 @@ def _handle_fn_body(body: list[ast.stmt], ctx: Context) -> sympy.Expr | None:
             target_name = node.targets[0].id
             return ctx.symbols[target_name]
 
-    msg = "No return value found in function body"
+    msg = "Rate function has no return statement — add 'return <float_expr>' at the end of the function"
     raise ValueError(msg)
 
 
@@ -662,7 +662,7 @@ def _handle_expr(node: ast.expr, ctx: Context) -> sympy.Expr | None:
     if isinstance(node, ast.Constant):
         if isinstance(val := node.value, (float, int)):
             return sympy.Float(val)
-        msg = "Can only use float values"
+        msg = f"Non-numeric constant {node.value!r} (type {type(node.value).__name__!r}) not supported in rate functions — only int/float literals are allowed"
         raise NotImplementedError(msg)
     if isinstance(node, ast.Call):
         return _handle_call(node, ctx=ctx)
@@ -707,7 +707,7 @@ def _handle_expr(node: ast.expr, ctx: Context) -> sympy.Expr | None:
         if_false = _handle_expr(node.orelse, ctx)
         return sympy.Piecewise((if_true, condition), (if_false, True))
 
-    msg = f"Expression type {type(node).__name__} not implemented"
+    msg = f"Expression type {type(node).__name__!r} is not supported in symbolic conversion — simplify the rate function to use only arithmetic operators and supported math functions"
     raise NotImplementedError(msg)
 
 
@@ -734,7 +734,7 @@ def _handle_unaryop(node: ast.UnaryOp, ctx: Context) -> sympy.Expr:
         case ast.USub():
             return -left
         case _:
-            msg = f"Operation {type(node.op).__name__} not implemented"
+            msg = f"Unary operator {type(node.op).__name__!r} is not supported — only +x and -x are allowed in rate functions"
             raise NotImplementedError(msg)
 
 
@@ -761,7 +761,7 @@ def _handle_binop(node: ast.BinOp, ctx: Context) -> sympy.Expr:
         case ast.FloorDiv():
             return left // right
         case _:
-            msg = f"Operation {type(node.op).__name__} not implemented"
+            msg = f"Binary operator {type(node.op).__name__!r} is not supported in rate functions — allowed: +, -, *, /, **, %, //"
             raise NotImplementedError(msg)
 
 
@@ -853,7 +853,8 @@ def _handle_attribute(node: ast.Attribute, ctx: Context) -> sympy.Expr | None:
 
             module = modules.get(levels[-1])
         case _:
-            raise NotImplementedError
+            msg = f"Unsupported attribute access pattern in rate function: {ast.dump(node.value)[:100]!r}"
+            raise NotImplementedError(msg)
 
     # Fall-back to absolute import
     if module is None:
@@ -929,7 +930,8 @@ def _handle_call(node: ast.Call, ctx: Context) -> sympy.Expr | None:
             fns = dict(inspect.getmembers(module, predicate=callable))
             py_fn = fns.get(fn_name)
         case _:
-            raise NotImplementedError
+            msg = f"Unsupported function call pattern in rate function: {ast.dump(node.func)[:100]!r}"
+            raise NotImplementedError(msg)
 
     if py_fn is None:
         return None

--- a/src/mxlpy/minimizers/_scipy.py
+++ b/src/mxlpy/minimizers/_scipy.py
@@ -151,7 +151,7 @@ class GlobalScipyMinimizer(AbstractMinimizer):
         elif self.method == "direct":
             res = direct(res_fn, bounds)
         else:
-            msg = f"Unknown method {self.method}"
+            msg = f"Unknown minimizer method {self.method!r} — valid methods: 'basinhopping', 'differential_evolution', 'shgo', 'dual_annealing', 'direct'"
             raise NotImplementedError(msg)
         if res.success:
             return Result(

--- a/src/mxlpy/model.py
+++ b/src/mxlpy/model.py
@@ -572,7 +572,7 @@ class Model:
             if name in self._parameters or name in self._derived:
                 all_parameter_values[name] = cast(float, dependent[name])
             else:
-                msg = "Unknown target for static derived variable."
+                msg = f"Internal error: '{name}' appears in static_order but is not a parameter, variable, or derived — this is a bug in dependency sorting"
                 raise KeyError(msg)
 
         self._cache = ModelCache(
@@ -624,11 +624,12 @@ class Model:
 
         """
         if name == "time":
-            msg = "time is a protected variable for time"
+            msg = "'time' is a reserved identifier — it represents the simulation time and cannot be used as a parameter, variable, derived, or reaction name"
             raise KeyError(msg)
 
         if name in self._ids:
-            msg = f"Model already contains {ctx} called '{name}'"
+            existing_ctx = self._ids[name]
+            msg = f"Name '{name}' already exists as a {existing_ctx} — cannot add it as a {ctx}. Each name must be unique across all model components."
             raise NameError(msg)
         self._ids[name] = ctx
 
@@ -889,7 +890,7 @@ class Model:
 
         """
         if name not in self._parameters:
-            msg = f"{name!r} not found in parameters"
+            msg = f"Parameter {name!r} not found. Available parameters: {sorted(self._parameters)}"
             raise KeyError(msg)
 
         parameter = self._parameters[name]
@@ -1030,7 +1031,7 @@ class Model:
                             target = True
                             stoich[name] = value
                 if not target:
-                    msg = f"Reaction '{rxn_name}' not found in reactions or surrogates"
+                    msg = f"Reaction '{rxn_name}' not found. Available reactions: {sorted(self._reactions)}, surrogates: {sorted(self._surrogates)}"
                     raise KeyError(msg)
 
         return self
@@ -1324,7 +1325,7 @@ class Model:
 
         """
         if name not in self._variables:
-            msg = f"'{name}' not found in variables"
+            msg = f"Variable {name!r} not found. Available variables: {sorted(self._variables)}"
             raise KeyError(msg)
 
         variable = self._variables[name]
@@ -2140,7 +2141,7 @@ class Model:
 
         """
         if name not in self._surrogates:
-            msg = f"Surrogate '{name}' not found in model"
+            msg = f"Surrogate {name!r} not found. Available surrogates: {sorted(self._surrogates)}"
             raise KeyError(msg)
 
         if surrogate is None:
@@ -2865,7 +2866,8 @@ class Model:
                 elif (var := self._variables.get(arg)) is not None:
                     unit_per_arg[sympy.Symbol(arg)] = var.unit
                 else:
-                    raise NotImplementedError
+                    msg = f"Argument '{arg}' in reaction '{name}' is neither a parameter nor a variable — unit checking only supports parameters and variables"
+                    raise NotImplementedError(msg)
 
             symbolic_fn = fn_to_sympy(
                 rxn.fn,

--- a/src/mxlpy/sbml/_export.py
+++ b/src/mxlpy/sbml/_export.py
@@ -76,7 +76,7 @@ class IdentifierReplacer(ast.NodeTransformer):
     def __init__(self, mapping: dict[str, str]) -> None:
         self.mapping = mapping
 
-    def visit_Name(self, node: ast.Name) -> ast.Name:
+    def visit_Name(self, node: ast.Name) -> ast.Name:  # noqa: N802
         """Replace identifier names using the mapping.
 
         Parameters
@@ -97,7 +97,7 @@ class IdentifierReplacer(ast.NodeTransformer):
 
 
 class DocstringRemover(ast.NodeTransformer):
-    def visit_Expr(self, node: ast.Expr) -> ast.Expr | None:
+    def visit_Expr(self, node: ast.Expr) -> ast.Expr | None:  # noqa: N802
         """Remove docstring expression nodes.
 
         Parameters
@@ -127,7 +127,8 @@ def _convert_unaryop(node: ast.UnaryOp) -> libsbml.ASTNode:
         case ast.Not():
             op = libsbml.AST_LOGICAL_NOT
         case _:
-            raise NotImplementedError(type(node.op))
+            msg = f"Unary operator {type(node.op).__name__!r} is not supported in SBML export — supported: USub, Not"
+            raise NotImplementedError(msg)
 
     sbml_node = libsbml.ASTNode(op)
     sbml_node.addChild(operand)
@@ -152,7 +153,8 @@ def _convert_binop(node: ast.BinOp) -> libsbml.ASTNode:
         case ast.FloorDiv():
             op = libsbml.AST_FUNCTION_QUOTIENT
         case _:
-            raise NotImplementedError(type(node.op))
+            msg = f"Binary operator {type(node.op).__name__!r} is not supported in SBML export — supported: Mult, Add, Sub, Div, Pow, FloorDiv"
+            raise NotImplementedError(msg)
 
     sbml_node = libsbml.ASTNode(op)
     sbml_node.addChild(left)
@@ -178,7 +180,7 @@ def _convert_attribute(node: ast.Attribute) -> libsbml.ASTNode:
             sbml_node.setValue(np.nan)
             return sbml_node
 
-    msg = f"{parent}.{attr}"
+    msg = f"Attribute '{parent}.{attr}' is not supported in SBML export — supported attributes: math/np/numpy.{{e, pi, inf, nan}}"
     raise NotImplementedError(msg)
 
 
@@ -266,7 +268,7 @@ def _convert_call(node: ast.Call) -> libsbml.ASTNode:
     if isinstance(func, ast.Attribute):
         return _convert_library_call(node)
 
-    msg = f"Unknown call type: {type(func)}"
+    msg = f"Unsupported function call type {type(func).__name__!r} in SBML export — only direct calls (fn(...)) and attribute calls (module.fn(...)) are supported"
     raise NotImplementedError(msg)
 
 
@@ -290,7 +292,8 @@ def _convert_compare(node: ast.Compare) -> libsbml.ASTNode:
         case ast.GtE():
             op = libsbml.AST_RELATIONAL_GEQ
         case _:
-            raise NotImplementedError(type(node.ops[0]))
+            msg = f"Comparison operator {type(node.ops[0]).__name__!r} is not supported in SBML export — supported: Eq, NotEq, Lt, LtE, Gt, GtE"
+            raise NotImplementedError(msg)
 
     sbml_node = libsbml.ASTNode(op)
     sbml_node.addChild(left)
@@ -302,7 +305,7 @@ def _convert_node(node: ast.stmt | ast.expr) -> libsbml.ASTNode:
     match node:
         case ast.Return(value):
             if value is None:
-                msg = "Model function cannot return `None`"
+                msg = "Rate/derived function has a bare 'return' with no value — SBML export requires functions to return a float expression"
                 raise ValueError(msg)
             return _convert_node(value)
         case ast.UnaryOp():
@@ -324,7 +327,8 @@ def _convert_node(node: ast.stmt | ast.expr) -> libsbml.ASTNode:
         case ast.Compare():
             return _convert_compare(node)
         case _:
-            raise NotImplementedError(type(node))
+            msg = f"AST node type {type(node).__name__!r} is not supported in SBML export — simplify the rate function to use only arithmetic and supported math functions"
+            raise NotImplementedError(msg)
 
 
 def _handle_body(stmts: list[ast.stmt]) -> libsbml.ASTNode:
@@ -593,7 +597,7 @@ def _create_sbml_reactions(
                     sref.setId(_convert_id_to_sbml(id_=reference, prefix="CPD"))
                     sref.setSpecies(_convert_id_to_sbml(id_=compound_id, prefix="CPD"))
                 case _:
-                    msg = f"Stoichiometry type {type(factor)} not supported"
+                    msg = f"Stoichiometry coefficient for '{compound_id}' has unsupported type {type(factor).__name__!r} — expected float or Derived"
                     raise NotImplementedError(msg)
         for compound_id in rxn.get_modifiers(model):
             sref = sbml_rxn.createModifier()

--- a/src/mxlpy/simulator.py
+++ b/src/mxlpy/simulator.py
@@ -373,7 +373,7 @@ class Simulator:
             0.0 if (variables := self.variables) is None else variables[-1].index[-1]
         )
         if t_end <= prior_t_end:
-            msg = "End time point has to be larger than previous end time point"
+            msg = f"t_end={t_end} must be greater than the last simulated time point ({prior_t_end}). Call reset() to restart the simulation from t=0."
             raise ValueError(msg)
 
         self._handle_simulation_results(
@@ -419,7 +419,7 @@ class Simulator:
             0.0 if (variables := self.variables) is None else variables[-1].index[-1]
         )
         if time_points[-1] <= prior_t_end:
-            msg = "End time point has to be larger than previous end time point"
+            msg = f"Final time point {time_points[-1]} must be greater than the last simulated time point ({prior_t_end}). Call reset() to restart the simulation from t=0."
             raise ValueError(msg)
 
         # Remove points which are smaller than previous t_end
@@ -533,7 +533,7 @@ class Simulator:
 
         # Error handling
         if time_points[-1] <= t_start:
-            msg = "End time point has to be larger than previous end time point"
+            msg = f"Final time point {time_points[-1]} must be greater than the protocol start time ({t_start}). Call reset() to restart the simulation from t=0."
             raise ValueError(msg)
 
         larger = time_points > protocol.index[-1]

--- a/src/mxlpy/types.py
+++ b/src/mxlpy/types.py
@@ -151,7 +151,7 @@ class Option[T]:
     def unwrap_or_err(self) -> T:
         """Obtain value if Ok, else raise exception."""
         if (value := self.value) is None:
-            msg = "Unexpected `None`"
+            msg = "Option contains None — use .default(fn) to provide a fallback value instead of .unwrap_or_err()"
             raise ValueError(msg)
         return value
 

--- a/tests/simulator/test_edge_cases.py
+++ b/tests/simulator/test_edge_cases.py
@@ -30,19 +30,19 @@ def get_model() -> Model:
 def test_simulate_backwards_time() -> None:
     """simulate(5) after simulate(10) must raise, not silently succeed."""
     sim = Simulator(get_model()).simulate(10, steps=10)
-    with pytest.raises(ValueError, match="larger than previous"):
+    with pytest.raises(ValueError, match="must be greater than"):
         sim.simulate(5)
 
 
 def test_simulate_negative_t_end() -> None:
     """simulate(-1) on fresh simulator: t_end=-1 <= prior_t_end=0, must raise."""
-    with pytest.raises(ValueError, match="larger than previous"):
+    with pytest.raises(ValueError, match="must be greater than"):
         Simulator(get_model()).simulate(-1)
 
 
 def test_simulate_zero_t_end() -> None:
     """simulate(0) on fresh simulator: equal to prior_t_end=0, must raise."""
-    with pytest.raises(ValueError, match="larger than previous"):
+    with pytest.raises(ValueError, match="must be greater than"):
         Simulator(get_model()).simulate(0)
 
 


### PR DESCRIPTION
## Summary

- Error messages throughout `model.py`, `simulator.py`, `sbml/_export.py`, `meta/source_tools.py`, and several other modules were vague or incomplete — they omitted the offending value, the expected value, and any remediation hint.
- Each message now includes the relevant names/values (e.g. available parameters listed when a lookup fails), identifies the unsupported construct, and where applicable tells the user how to fix the issue (e.g. "Call reset() to restart from t=0").
- Fixes one copy-paste bug: `"time is a protected variable for time"` is now a coherent message.

## Test plan

- Three simulator edge-case tests updated to match the new wording — run `uv run pytest tests/simulator/test_edge_cases.py`.
- Full suite: `uv run pytest --disable-warnings tests/` (2261 passed, 3 torch-import errors are pre-existing and unrelated).