### PR TITLE
feat(plot): add network() for reaction network visualisation

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,10 +18,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.13.12
 
       - name: Set Python version
-        run: uv venv --python 3.13
+        run: uv venv --python 3.13.12
 
       - name: Set up environment
         run: uv sync --all-extras --all-groups
@@ -30,7 +30,9 @@ jobs:
         run: uv run pytest --disable-warnings --cov --cov-report json tests/
 
       - name: Get coverage value
-        run: python -c "import json; print('COVERAGE={}'.format(json.load(open('coverage.json'))['totals']['percent_covered_display']))" >> $GITHUB_ENV
+        run: python -c "import json;
+          print('COVERAGE={}'.format(json.load(open('coverage.json'))['totals']['percent_covered_display']))"
+          >> $GITHUB_ENV
 
       - name: Coverage badge
         uses: schneegans/dynamic-badges-action@v1.7.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: documentation
 
 on:
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch: {}
 
 permissions:
@@ -25,10 +25,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.13.12
 
       - name: Set Python version
-        run: uv venv --python 3.13
+        run: uv venv --python 3.13.12
 
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v4
@@ -38,6 +38,8 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: uv sync --all-extras --all-groups
-      - run: uv run python -c "import toml;print('VERSION={}'.format(toml.load(open('pyproject.toml'))['project']['version']))" >> $GITHUB_ENV
+      - run: uv run python -c "import
+          toml;print('VERSION={}'.format(toml.load(open('pyproject.toml'))['project']['version']))"
+          >> $GITHUB_ENV
       - run: uv run mike deploy --update-aliases --push ${{ env.VERSION }} latest
       - run: uv run mike set-default --push latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -2,7 +2,7 @@ name: Upload Python Package
 
 on:
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch: {}
 
 permissions:
@@ -18,10 +18,10 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.13.12
 
       - name: Set Python version
-        run: uv venv --python 3.13
+        run: uv venv --python 3.13.12
 
       - name: Build release distribution
         run: uv build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,12 +18,18 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Set up Python
-        run: uv python install 3.13
+        run: uv python install 3.13.12
 
       - name: Set Python version
-        run: uv venv --python 3.13
+        run: uv venv --python 3.13.12
 
-      - name: Set up environment
+      - name: Set up minimal environment
+        run: uv sync
+
+      - name: Check that import always works
+        run: uv run python -c "import mxlpy"
+
+      - name: Set up maximal environment
         run: uv sync --all-extras --all-groups
 
       - name: Run tests

--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from example_models import get_linear_chain_2v\n",
+    "from example_models import get_linear_chain_2v, get_poolman2000\n",
     "\n",
     "\n",
     "def print_annotated(description: str, value: Any) -> None:\n",
@@ -161,7 +161,7 @@
     "\n",
     "model = model.add_parameters(\n",
     "    {\n",
-    "        \"k_in\": 1,\n",
+    "        \"k1\": 1,\n",
     "        \"k_1\": Parameter(1, unit=units.mmol_s),\n",
     "        \"k_out\": 1,\n",
     "    }\n",
@@ -219,7 +219,7 @@
     "model.add_reaction(\n",
     "    \"v0\",\n",
     "    fn=constant,\n",
-    "    args=[\"k_in\"],\n",
+    "    args=[\"k1\"],\n",
     "    stoichiometry={\"S\": 1},  # produces one S\n",
     ")\n",
     "model.add_reaction(\n",
@@ -273,7 +273,7 @@
     "        Model()\n",
     "        .add_parameters(\n",
     "            {\n",
-    "                \"k_in\": Parameter(1, unit=units.mmol_s),\n",
+    "                \"k1\": Parameter(1, unit=units.mmol_s),\n",
     "                \"k_1\": Parameter(1, unit=units.per_second),\n",
     "                \"k_out\": Parameter(1, unit=units.per_second),\n",
     "            }\n",
@@ -287,7 +287,7 @@
     "        .add_reaction(\n",
     "            \"v0\",\n",
     "            fn=constant,\n",
-    "            args=[\"k_in\"],\n",
+    "            args=[\"k1\"],\n",
     "            stoichiometry={\"S\": 1},  # produces one S\n",
     "            unit=units.mmol_s,\n",
     "        )\n",
@@ -607,7 +607,7 @@
     ")\n",
     "\n",
     "# Update parameters\n",
-    "m.update_parameters({\"k_in\": 2.0})\n",
+    "m.update_parameters({\"k1\": 2.0})\n",
     "\n",
     "# Calculate fluxes again\n",
     "print_annotated(\n",
@@ -964,6 +964,33 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Visualizing model structure\n",
+    "\n",
+    "`mxlpy` can render a model's reaction network as a directed graph using `plot.network` using [networkx](https://networkx.org/) under the hood.\n",
+    "\n",
+    "Variables are displayed as circles and reactions as squares. Solid arrows show a stoichiometric edge (e.g. substrate → reaction or reaction → product) and dashed edges show modifiers (variable appears in `args` but not in stoichiometry)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = plot.network(\n",
+    "    get_poolman2000(),\n",
+    "    layout=\"kamada_kawai\",\n",
+    "    cofactors=[\"ATP\", \"NADPH\"],\n",
+    "    ax=plot.one_axes(figsize=(12, 8))[1],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## SBML\n",
     "\n",
     "The systems biology markup language (SBML) is a widely used file format for sharing models between different software packages and programming languages.  \n",
@@ -1207,7 +1234,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mxlpy (3.12.11)",
+   "display_name": "git-mxl-meta (3.13.12)",
    "language": "python",
    "name": "python3"
   },
@@ -1221,7 +1248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.14.3"
+   "version": "3.13.12"
   }
  },
  "nbformat": 4,

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -31,8 +31,8 @@ def get_model() -> Model:
     return (
         Model()
         .add_variables({"x": 1.0})
-        .add_parameters({"k_in": 1.0, "k_out": 1.0})
-        .add_reaction("v_in", constant, stoichiometry={"x": 1}, args=["k_in"])
+        .add_parameters({"k1": 1.0, "k_out": 1.0})
+        .add_reaction("v_in", constant, stoichiometry={"x": 1}, args=["k1"])
         .add_reaction("v_out", mass_action_1s, stoichiometry={"x": -1}, args=["k_out", "x"])
     )
 ```
@@ -77,8 +77,8 @@ from mxlpy.fns import constant, michaelis_menten_1s
 model = (
     Model()
     .add_variables({"s": 1.0, "p": 0.0})
-    .add_parameters({"k_in": 1.0, "vmax": 2.0, "km": 0.5})
-    .add_reaction("v_in", constant, stoichiometry={"s": 1}, args=["k_in"])
+    .add_parameters({"k1": 1.0, "vmax": 2.0, "km": 0.5})
+    .add_reaction("v_in", constant, stoichiometry={"s": 1}, args=["k1"])
     .add_reaction("v_enzyme", michaelis_menten_1s, stoichiometry={"s": -1, "p": 1}, args=["s", "vmax", "km"])
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
     "matplotlib>=3.9.2",
     "mike>=2.1.3",
     "more-itertools>=10.5.0",
+    "networkx>=3.0",
     "numpy>=2.1.2",
     "pandas>=2.2.3",
     "parameteriser>=0.1.0",
@@ -77,7 +78,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.41.0"
+version = "0.42.0"
 
 [project.optional-dependencies]
 jax = [

--- a/src/example_models/linear_chain.py
+++ b/src/example_models/linear_chain.py
@@ -13,12 +13,12 @@ def get_linear_chain_1v() -> Model:
     return (
         Model()
         .add_variables({"x": 1.0})
-        .add_parameters({"k_in": 1.0, "k_out": 1.0})
+        .add_parameters({"k1": 1.0, "k_out": 1.0})
         .add_reaction(
             "v_in",
             constant,
             stoichiometry={"x": 1},
-            args=["k_in"],
+            args=["k1"],
         )
         .add_reaction(
             "v_out",
@@ -34,12 +34,12 @@ def get_linear_chain_2v() -> Model:
     return (
         Model()
         .add_variables({"x": 1.0, "y": 1.0})
-        .add_parameters({"k_in": 1.0, "k2": 2.0, "k_out": 1.0})
+        .add_parameters({"k1": 1.0, "k2": 2.0, "k_out": 1.0})
         .add_reaction(
             "v1",
             constant,
             stoichiometry={"x": 1},
-            args=["k_in"],
+            args=["k1"],
         )
         .add_reaction(
             "v2",

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import contextlib
 import itertools as it
+import logging
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -123,6 +124,7 @@ __all__ = [
     "Variable",
     "cartesian_product",
     "compare",
+    "configure_default_logging",
     "distributions",
     "experimental",
     "fit",
@@ -209,3 +211,18 @@ def make_protocol(steps: list[tuple[float, dict[str, float]]]) -> pd.DataFrame:
     protocol = pd.DataFrame(data).T
     protocol.index.name = "Timedelta"
     return protocol
+
+
+def configure_default_logging(
+    fmt: str = "%(levelname)s:%(name)s:%(message)s",
+    level: logging._Level = logging.DEBUG,
+) -> None:
+    """Create a default logging config."""
+    logger = logging.getLogger("mxlpy")
+    if logger.handlers:
+        return
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(handler)
+    logger.setLevel(level)

--- a/src/mxlpy/meta/_via_sym_repr.py
+++ b/src/mxlpy/meta/_via_sym_repr.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
     from mxlpy.model import Model
 
-_LOGGER = logging.getLogger()
+_LOGGER = logging.getLogger(__name__)
 
 
 __all__ = [
@@ -70,8 +70,6 @@ __all__ = [
     "valid_identifier",
     "valid_tex_identifier",
 ]
-
-_LOGGER = logging.getLogger()
 
 
 class NormalizedSymbolicModel(NamedTuple):
@@ -1136,6 +1134,7 @@ def generate_model_code_mxlweb(
     tex_names: dict[str, str] | None = None,
     custom_fns: dict[str, sympy.Expr | list[sympy.Expr]] | None = None,
     sliders: dict[str, dict[str, str]] | None = None,
+    docstring: str | None = None,
 ) -> str:
     """Generate TypeScript source for the mxlweb browser simulator.
 
@@ -1362,7 +1361,7 @@ def generate_model_code_mxlweb(
         [
             f'import {{ {mathml_import_str} }} from "$lib/mathml";',
             'import { ModelBuilder } from "$lib/model-editor/modelBuilder";',
-            "",
+            f"\n{docstring}" if docstring else "",
             model_builder_str,
         ]
     )

--- a/src/mxlpy/meta/codegen_mxlpy.py
+++ b/src/mxlpy/meta/codegen_mxlpy.py
@@ -29,14 +29,19 @@ if TYPE_CHECKING:
 
 __all__ = ["Context", "generate_mxlpy_code"]
 
-_LOGGER = logging.getLogger()
+_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
 class Context:
+    """Various config."""
+
     functions: dict[str, str]
     mxlpy_imports: set[str]
     file_imports: set[str]
+    strip_docstring: bool
+    first: str
+    space: str
 
 
 def _fn_name(k: str, fn: Callable) -> str:
@@ -49,42 +54,29 @@ def _handle_fn_source(
     args: list[str],
     *,
     ctx: Context,
-    strip_docstring: bool,
 ) -> str:
     fn_name = _fn_name(name, fn)
-    extracted = fn_to_source(fn, fn_name, args, strip_docstring=strip_docstring)
+    extracted = fn_to_source(fn, fn_name, args, strip_docstring=ctx.strip_docstring)
     ctx.functions.update(extracted.dependencies)
     ctx.functions[fn_name] = extracted.main_source
     ctx.file_imports.update(extracted.imports)
     return fn_name
 
 
-def _codegen_variable(
-    k: str,
-    variable: Variable,
-    *,
-    ctx: Context,
-    strip_docstring: bool,
-) -> str:
+def _codegen_variable(k: str, variable: Variable, *, ctx: Context) -> str:
     val = variable.initial_value
     if isinstance(val, InitialAssignment):
-        fn_name = _handle_fn_source(
-            k,
-            val.fn,
-            val.args,
-            ctx=ctx,
-            strip_docstring=strip_docstring,
-        )
+        fn_name = _handle_fn_source(k, val.fn, val.args, ctx=ctx)
         ctx.mxlpy_imports.add("InitialAssignment")
         return (
-            "        .add_variable(\n"
-            f"            {k!r},\n"
-            f"            initial_value=InitialAssignment(fn={fn_name}, args={val.args!r}),\n"
-            "        )"
+            f"{ctx.first}.add_variable(\n"
+            f"{ctx.space}  {k!r},\n"
+            f"{ctx.space}  initial_value=InitialAssignment(fn={fn_name}, args={val.args!r}),\n"
+            f"{ctx.space})"
         )
 
     # val is float | int
-    return f"        .add_variable({k!r}, initial_value={val!r})"
+    return f"{ctx.first}.add_variable({k!r}, initial_value={val!r})"
 
 
 def _codegen_parameter(
@@ -92,27 +84,20 @@ def _codegen_parameter(
     parameter: Parameter,
     *,
     ctx: Context,
-    strip_docstring: bool,
 ) -> str:
     val = parameter.value
     if isinstance(val, InitialAssignment):
-        fn_name = _handle_fn_source(
-            k,
-            val.fn,
-            val.args,
-            ctx=ctx,
-            strip_docstring=strip_docstring,
-        )
+        fn_name = _handle_fn_source(k, val.fn, val.args, ctx=ctx)
         ctx.mxlpy_imports.add("InitialAssignment")
         return (
-            "        .add_parameter(\n"
-            f"            {k!r},\n"
-            f"            value=InitialAssignment(fn={fn_name}, args={val.args!r}),\n"
-            "        )"
+            f"{ctx.first}.add_parameter(\n"
+            f"{ctx.space}  {k!r},\n"
+            f"{ctx.space} value=InitialAssignment(fn={fn_name}, args={val.args!r}),\n"
+            f"{ctx.space})"
         )
 
     # val is float | int
-    return f"        .add_parameter({k!r}, value={val!r})"
+    return f"{ctx.first}.add_parameter({k!r}, value={val!r})"
 
 
 def _codegen_derived(
@@ -120,21 +105,19 @@ def _codegen_derived(
     der: Derived,
     *,
     ctx: Context,
-    strip_docstring: bool,
 ) -> str:
     fn_name = _handle_fn_source(
         k,
         der.fn,
         der.args,
         ctx=ctx,
-        strip_docstring=strip_docstring,
     )
     return (
-        "        .add_derived(\n"
-        f"            {k!r},\n"
-        f"            fn={fn_name},\n"
-        f"            args={der.args!r},\n"
-        "        )"
+        f"{ctx.first}.add_derived(\n"
+        f"{ctx.space}  {k!r},\n"
+        f"{ctx.space}  fn={fn_name},\n"
+        f"{ctx.space}  args={der.args!r},\n"
+        f"{ctx.space})"
     )
 
 
@@ -143,14 +126,12 @@ def _codegen_reaction(
     rxn: Reaction,
     *,
     ctx: Context,
-    strip_docstring: bool,
 ) -> str:
     fn_name = _handle_fn_source(
         k,
         rxn.fn,
         rxn.args,
         ctx=ctx,
-        strip_docstring=strip_docstring,
     )
 
     stoichiometry: list[str] = []
@@ -162,7 +143,6 @@ def _codegen_reaction(
                 stoich.fn,
                 stoich.args,
                 ctx=ctx,
-                strip_docstring=strip_docstring,
             )
             stoichiometry.append(
                 f'"{var}": Derived(fn={stoich_fn_name}, args={stoich.args!r})'
@@ -170,12 +150,12 @@ def _codegen_reaction(
         else:
             stoichiometry.append(f'"{var}": {stoich!r}')
     return (
-        "        .add_reaction(\n"
-        f"            {k!r},\n"
-        f"            fn={fn_name},\n"
-        f"            args={rxn.args!r},\n"
-        f"            stoichiometry={{{','.join(stoichiometry)}}},\n"
-        "        )"
+        f"{ctx.first}.add_reaction(\n"
+        f"{ctx.space}  {k!r},\n"
+        f"{ctx.space}  fn={fn_name},\n"
+        f"{ctx.space}  args={rxn.args!r},\n"
+        f"{ctx.space}  stoichiometry={{{','.join(stoichiometry)}}},\n"
+        f"{ctx.space})"
     )
 
 
@@ -184,7 +164,6 @@ def _codegen_surrogate(
     surrogate: SurrogateProtocol,
     *,
     ctx: Context,
-    strip_docstring: bool,
 ) -> str | None:
     stype = type(surrogate)
     module = stype.__module__
@@ -211,7 +190,6 @@ def _codegen_surrogate(
                 model_attr,
                 surrogate.args,
                 ctx=ctx,
-                strip_docstring=strip_docstring,
             )
         except (ValueError, TypeError, OSError) as exc:
             _LOGGER.warning(
@@ -236,7 +214,6 @@ def _codegen_surrogate(
                         factor.fn,
                         factor.args,
                         ctx=ctx,
-                        strip_docstring=strip_docstring,
                     )
                     rxn_parts.append(
                         f'"{var}": Derived(fn={sf_name}, args={factor.args!r})'
@@ -248,12 +225,12 @@ def _codegen_surrogate(
 
     ctor_str = ",\n                ".join(ctor_parts)
     return (
-        "        .add_surrogate(\n"
-        f"            {k!r},\n"
-        f"            {class_ref}(\n"
-        f"                {ctor_str},\n"
-        "            ),\n"
-        "        )"
+        f"{ctx.first}.add_surrogate(\n"
+        f"{ctx.space}  {k!r},\n"
+        f"{ctx.space}  {class_ref}(\n"
+        f"{ctx.space}    {ctor_str},\n"
+        f"{ctx.space}    ),\n"
+        f"{ctx.space})"
     )
 
 
@@ -262,21 +239,19 @@ def _codegen_readout(
     der: Readout,
     *,
     ctx: Context,
-    strip_docstring: bool,
 ) -> str:
     fn_name = _handle_fn_source(
         k,
         der.fn,
         der.args,
         ctx=ctx,
-        strip_docstring=strip_docstring,
     )
     return (
-        "        .add_readout(\n"
-        f"            {k!r},\n"
-        f"            fn={fn_name},\n"
-        f"            args={der.args!r},\n"
-        "        )"
+        f"{ctx.first}.add_readout(\n"
+        f"{ctx.space}  {k!r},\n"
+        f"{ctx.space}  fn={fn_name},\n"
+        f"{ctx.space}  args={der.args!r},\n"
+        f"{ctx.space})"
     )
 
 
@@ -286,6 +261,8 @@ def generate_mxlpy_code(
     model_fn_name: str = "create_model",
     imports: list[str] | None = None,
     strip_docstring: bool = True,
+    as_assignment: bool = False,
+    docstring: str | None = None,
 ) -> str:
     """Generate MxlPy source code without a symbolic representation round-trip.
 
@@ -306,80 +283,41 @@ def generate_mxlpy_code(
         functions={},
         mxlpy_imports={"Model"},
         file_imports=set() if imports is None else set(imports),
+        first="    m = m" if as_assignment else "        ",
+        space="    " if as_assignment else "        ",
+        strip_docstring=strip_docstring,
     )
 
     # Variables
     variable_source = []
     for k, variable in model.get_raw_variables().items():
-        variable_source.append(
-            _codegen_variable(
-                k,
-                variable,
-                ctx=ctx,
-                strip_docstring=strip_docstring,
-            )
-        )
+        variable_source.append(_codegen_variable(k, variable, ctx=ctx))
 
     # Parameters
     parameter_source = []
     for k, parameter in model.get_raw_parameters().items():
-        parameter_source.append(
-            _codegen_parameter(
-                k,
-                parameter,
-                ctx=ctx,
-                strip_docstring=strip_docstring,
-            )
-        )
+        parameter_source.append(_codegen_parameter(k, parameter, ctx=ctx))
 
     # Derived
     derived_source = []
     for k, der in model.get_raw_derived().items():
-        derived_source.append(
-            _codegen_derived(
-                k,
-                der,
-                ctx=ctx,
-                strip_docstring=strip_docstring,
-            )
-        )
+        derived_source.append(_codegen_derived(k, der, ctx=ctx))
 
     # Reactions
     reactions_source = []
     for k, rxn in model.get_raw_reactions().items():
-        reactions_source.append(
-            _codegen_reaction(
-                k,
-                rxn,
-                ctx=ctx,
-                strip_docstring=strip_docstring,
-            )
-        )
+        reactions_source.append(_codegen_reaction(k, rxn, ctx=ctx))
 
     # Surrogates
     surrogate_source = []
     for k, surrogate in model.get_raw_surrogates().items():
-        if (
-            gen := _codegen_surrogate(
-                k,
-                surrogate,
-                ctx=ctx,
-                strip_docstring=strip_docstring,
-            )
-        ) is not None:
+        if (gen := _codegen_surrogate(k, surrogate, ctx=ctx)) is not None:
             surrogate_source.append(gen)
 
     # Surrogates
     readout_source = []
     for k, ro in model.get_raw_readouts().items():
-        readout_source.append(
-            _codegen_readout(
-                k,
-                ro,
-                ctx=ctx,
-                strip_docstring=strip_docstring,
-            )
-        )
+        readout_source.append(_codegen_readout(k, ro, ctx=ctx))
 
     functions_source = "\n\n".join(ctx.functions.values())
     fn_block = "\n" if len(ctx.functions) == 0 else f"\n\n{functions_source}\n"
@@ -389,9 +327,14 @@ def generate_mxlpy_code(
         f"from mxlpy import {','.join(sorted(ctx.mxlpy_imports))}",
         fn_block,
         f"def {model_fn_name}() -> Model:",
-        "    return (",
-        "        Model()",
     ]
+    if docstring is not None:
+        source.append(f"    {docstring}")
+    if as_assignment:
+        source.append("    m: Model = Model()")
+    else:
+        source.append("    return (")
+        source.append("        Model()")
     if variable_source:
         source.append("\n".join(variable_source))
     if parameter_source:
@@ -404,5 +347,8 @@ def generate_mxlpy_code(
         source.append("\n".join(surrogate_source))
     if readout_source:
         source.append("\n".join(readout_source))
-    source.append("    )")
+    if as_assignment:
+        source.append("    return m  # noqa: RET504")
+    else:
+        source.append("    )")
     return "\n".join(source)

--- a/src/mxlpy/meta/source_tools.py
+++ b/src/mxlpy/meta/source_tools.py
@@ -367,7 +367,10 @@ def get_fn_ast(fn: Callable, *, strip_docstring: bool = False) -> ast.FunctionDe
     """
     tree = ast.parse(textwrap.dedent(get_fn_source(fn)))
     if not isinstance(fn_def := tree.body[0], ast.FunctionDef):
-        msg = f"Expected a function definition but got {type(fn_def).__name__} - pass a named function, not a class or bare expression"
+        msg = (
+            f"Expected a function definition but got {type(fn_def).__name__} - "
+            "pass a named function, not a class or bare expression"
+        )
         raise TypeError(msg)
     if (
         strip_docstring
@@ -404,7 +407,10 @@ def _handle_fn_body_outputs(
                             ctx.symbols[target.id] = expr
             else:
                 if not isinstance(target := node.targets[0], ast.Name):
-                    msg = f"Only simple 'x = expr' assignments are supported in rate functions - got {type(target).__name__} assignment target at line {node.lineno}"
+                    msg = (
+                        "Only simple 'x = expr' assignments are supported in rate functions"
+                        f" - got {type(target).__name__} assignment target at line {node.lineno}"
+                    )
                     raise TypeError(msg)
                 value = _handle_expr(node.value, ctx)
                 if value is None:
@@ -485,7 +491,10 @@ def _handle_fn_body(body: list[ast.stmt], ctx: Context) -> sympy.Expr | None:
 
         elif isinstance(node, ast.Return):
             if (value := node.value) is None:
-                msg = "Bare 'return' with no value is not supported in rate functions - return a float expression"
+                msg = (
+                    "Bare 'return' with no value is not supported in rate functions"
+                    " - return a float expression"
+                )
                 raise ValueError(msg)
 
             expr = _handle_expr(value, ctx)
@@ -517,7 +526,10 @@ def _handle_fn_body(body: list[ast.stmt], ctx: Context) -> sympy.Expr | None:
             else:
                 # Regular single assignment
                 if not isinstance(target := node.targets[0], ast.Name):
-                    msg = f"Only simple 'x = expr' assignments are supported in rate functions - got {type(target).__name__} assignment target at line {node.lineno}"
+                    msg = (
+                        f"Only simple 'x = expr' assignments are supported in rate functions"
+                        f" - got {type(target).__name__} assignment target at line {node.lineno}"
+                    )
                     raise TypeError(msg)
                 target_name = target.id
                 value = _handle_expr(node.value, ctx)
@@ -623,7 +635,10 @@ def _handle_expr(node: ast.expr, ctx: Context) -> sympy.Expr | None:
         if_false = _handle_expr(node.orelse, ctx)
         return sympy.Piecewise((if_true, condition), (if_false, True))
 
-    msg = f"Expression type {type(node).__name__!r} is not supported in symbolic conversion - simplify the rate function to use only arithmetic operators and supported math functions"
+    msg = (
+        f"Expression type {type(node).__name__!r} is not supported in symbolic conversion"
+        " - simplify the rate function to use only arithmetic operators and supported math functions"
+    )
     raise NotImplementedError(msg)
 
 
@@ -650,7 +665,10 @@ def _handle_unaryop(node: ast.UnaryOp, ctx: Context) -> sympy.Expr:
         case ast.USub():
             return -left
         case _:
-            msg = f"Unary operator {type(node.op).__name__!r} is not supported - only +x and -x are allowed in rate functions"
+            msg = (
+                f"Unary operator {type(node.op).__name__!r} is not supported"
+                " - only +x and -x are allowed in rate functions"
+            )
             raise NotImplementedError(msg)
 
 
@@ -677,7 +695,10 @@ def _handle_binop(node: ast.BinOp, ctx: Context) -> sympy.Expr:
         case ast.FloorDiv():
             return left // right
         case _:
-            msg = f"Binary operator {type(node.op).__name__!r} is not supported in rate functions - allowed: +, -, *, /, **, %, //"
+            msg = (
+                f"Binary operator {type(node.op).__name__!r} is not supported in rate functions"
+                " - allowed: +, -, *, /, **, %, //"
+            )
             raise NotImplementedError(msg)
 
 
@@ -873,7 +894,10 @@ def _lambda_to_def(source: str, fn_name: str, args: list[str]) -> str:
         None,
     )
     if lambda_node is None:
-        msg = f"Could not find a lambda expression in the source of '{fn_name}' - the source may belong to a different statement or the lambda is not at module scope"
+        msg = (
+            f"Could not find a lambda expression in the source of '{fn_name}'"
+            " - the source may belong to a different statement or the lambda is not at module scope"
+        )
         raise ValueError(msg)
 
     fn_args = ast.arguments(
@@ -1192,7 +1216,17 @@ def fn_to_sympy_expr(
         if isinstance(sympy_expr, float):
             return sympy.Float(sympy_expr)
         if model_args is not None and len(model_args):
-            sympy_expr = sympy_expr.subs(dict(zip(fn_args, model_args, strict=True)))
+            try:
+                sympy_expr = sympy_expr.subs(
+                    dict(zip(fn_args, model_args, strict=True))
+                )
+            except ValueError as e:
+                _LOGGER.warning("fn name: %s", fn.__name__)
+                _LOGGER.warning(
+                    "\n    fn args: %s \n    model args: %s", fn_args, model_args
+                )
+                raise ValueError from e
+
         return cast(sympy.Expr, sympy_expr)
 
     except (TypeError, ValueError, NotImplementedError) as e:
@@ -1250,7 +1284,7 @@ def fn_to_sympy_exprs(
             exprs = [cast(sympy.Expr, e.subs(subs)) for e in exprs]
 
     except (TypeError, ValueError, NotImplementedError) as e:
-        msg = f"Failed parsing function of {origin}"
+        msg = f"Failed parsing function '{fn.__name__}' of {origin}"
         _LOGGER.warning(msg)
         _LOGGER.debug("", exc_info=e)
         return None

--- a/src/mxlpy/plot.py
+++ b/src/mxlpy/plot.py
@@ -24,6 +24,7 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, cast, overload
 
+import networkx as nx
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -44,6 +45,7 @@ from mpl_toolkits.mplot3d import Axes3D
 from wadler_lindig import pformat
 
 from mxlpy.label_map import LabelMapper
+from mxlpy.types import Derived
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Iterator
@@ -79,6 +81,7 @@ __all__ = [
     "lines",
     "lines_grouped",
     "lines_mean_std_from_2d_idx",
+    "network",
     "one_axes",
     "relative_label_distribution",
     "reset_prop_cycle",
@@ -1792,3 +1795,142 @@ def relative_label_distribution(
             ax.legend([f"C{i + 1}" for i in range(len(isos))])
 
     return fig, axs
+
+
+def network(
+    model: Model,
+    *,
+    node_size: float = 500,
+    cofactors: list[str] | None = None,
+    layout: str = "kamada_kawai",
+    ax: Axes | None = None,
+) -> tuple[Figure, Axes]:
+    """Plot reaction network topology as a directed graph.
+
+    Species are shown as circles, reactions as squares. Stoichiometric
+    edges are solid arrows; modifier edges (args not in stoichiometry)
+    are dashed. Cofactor species are rendered as per-reaction copies
+    to avoid visual clutter from high-degree hub nodes.
+
+    Parameters
+    ----------
+    model
+        Model whose topology to visualise.
+    cofactors
+        Species to render as per-reaction copies rather than as a
+        shared hub. Useful for ubiquitous metabolites like ATP or NADH.
+    layout
+        networkx layout algorithm name, e.g. ``"kamada_kawai"``,
+        ``"spring"``, ``"circular"``.
+    ax
+        Axes to draw on. If None, a new figure is created.
+
+    Returns
+    -------
+    tuple[Figure, Axes]
+        Figure and Axes containing the network diagram.
+
+    """
+    cofactor_set = set(cofactors or [])
+    args: dict[str, float] = {
+        **model.get_parameter_values(),
+        **model.get_initial_conditions(),
+    }
+
+    G: nx.DiGraph = nx.DiGraph()
+    species_nodes: list[str] = []
+    reaction_nodes: list[str] = []
+    regular_edges: list[tuple[str, str]] = []
+    modifier_edges: list[tuple[str, str]] = []
+    labels: dict[str, str] = {}
+
+    for name in model.get_variable_names():
+        if name not in cofactor_set:
+            G.add_node(name)
+            species_nodes.append(name)
+            labels[name] = name
+
+    for rxn_name, rxn in model.get_raw_reactions().items():
+        G.add_node(rxn_name)
+        reaction_nodes.append(rxn_name)
+        labels[rxn_name] = rxn_name
+
+        for species, stoich in rxn.stoichiometry.items():
+            try:
+                coeff: float = (
+                    stoich.calculate(args)
+                    if isinstance(stoich, Derived)
+                    else float(stoich)
+                )
+            except (KeyError, TypeError):
+                coeff = 1.0
+
+            if species in cofactor_set:
+                node_id = f"{species}__{rxn_name}"
+                if node_id not in G:
+                    G.add_node(node_id)
+                    species_nodes.append(node_id)
+                    labels[node_id] = species
+            else:
+                node_id = species
+
+            if coeff < 0:
+                regular_edges.append((node_id, rxn_name))
+            else:
+                regular_edges.append((rxn_name, node_id))
+
+        for mod in rxn.get_modifiers(model):
+            if mod in cofactor_set:
+                node_id = f"{mod}__{rxn_name}"
+                if node_id not in G:
+                    G.add_node(node_id)
+                    species_nodes.append(node_id)
+                    labels[node_id] = mod
+            else:
+                node_id = mod
+            modifier_edges.append((node_id, rxn_name))
+
+    G.add_edges_from(regular_edges)
+    G.add_edges_from(modifier_edges)
+
+    layout_fn = getattr(nx, f"{layout}_layout")
+    pos = layout_fn(G)
+
+    if ax is None:
+        fig, ax = plt.subplots()
+    else:
+        fig = cast(Figure, ax.get_figure())
+
+    ax.set_axis_off()
+
+    if species_nodes:
+        nx.draw_networkx_nodes(
+            G,
+            pos,
+            nodelist=species_nodes,
+            node_shape="o",
+            node_color="white",
+            edgecolors="black",
+            ax=ax,
+            node_size=node_size,
+        )
+    if reaction_nodes:
+        nx.draw_networkx_nodes(
+            G,
+            pos,
+            nodelist=reaction_nodes,
+            node_shape="s",
+            node_color="lightgray",
+            edgecolors="black",
+            ax=ax,
+            node_size=node_size,
+        )
+    if regular_edges:
+        nx.draw_networkx_edges(G, pos, edgelist=regular_edges, ax=ax, arrows=True)
+    if modifier_edges:
+        nx.draw_networkx_edges(
+            G, pos, edgelist=modifier_edges, style="dashed", ax=ax, arrows=True
+        )
+    nx.draw_networkx_labels(G, pos, labels=labels, ax=ax)
+
+    return fig, ax

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -19,11 +19,13 @@ from mxlpy.plot import (
     lines,
     lines_grouped,
     lines_mean_std_from_2d_idx,
+    network,
     rotate_xlabels,
     two_axes,
     violins,
     violins_from_2d_idx,
 )
+from tests.models import m_2v_1p_1d_1r, m_2v_2p_2d_2r
 
 
 @pytest.fixture
@@ -262,4 +264,25 @@ def test_violins(sample_dataframe: pd.DataFrame) -> None:
 def test_violins_from_2d_idx(multiindex_dataframe: pd.DataFrame) -> None:
     fig, axs = violins_from_2d_idx(multiindex_dataframe)
     assert isinstance(fig, Figure)
+    plt.close(fig)
+
+
+def test_network() -> None:
+    fig, ax = network(m_2v_2p_2d_2r())
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+    plt.close(fig)
+
+
+def test_network_with_cofactors() -> None:
+    fig, ax = network(m_2v_2p_2d_2r(), cofactors=["v1"])
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+    plt.close(fig)
+
+
+def test_network_with_existing_ax() -> None:
+    _fig0, ax0 = plt.subplots()
+    fig, ax = network(m_2v_1p_1d_1r(), ax=ax0)
+    assert ax is ax0
     plt.close(fig)


### PR DESCRIPTION
## Summary

- Adds `plot.network()` which renders a model's reaction topology as a directed graph via networkx: species as circles, reactions as squares, stoichiometric edges as solid arrows, modifier edges as dashed arrows.
- Cofactor species (e.g. ATP, NADH) can be duplicated per reaction via the `cofactors` parameter to avoid hub-node clutter in dense networks.
- Renames the example-model influx parameter `k_in` → `k1` for naming consistency; adds networkx as an explicit dependency and bumps version to 0.42.0.

## Test plan

- `uv run pytest tests/test_plot.py -k network` — covers basic call, cofactor argument, and reuse of an existing `Axes`.
- Visually verify the Poolman2000 network example in `docs/basics.ipynb` renders correctly.