### PR TITLE
feat(databases): add BioModels and JWS Online model integration

### DIFF
--- a/docs/basics.ipynb
+++ b/docs/basics.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from example_models import get_linear_chain_2v, get_poolman2000\n",
+    "from example_models import get_linear_chain_2v, get_lin_chain_two_circles\n",
     "\n",
     "\n",
     "def print_annotated(description: str, value: Any) -> None:\n",
@@ -980,10 +980,10 @@
    "outputs": [],
    "source": [
     "_ = plot.network(\n",
-    "    get_poolman2000(),\n",
+    "    get_lin_chain_two_circles(),\n",
     "    layout=\"kamada_kawai\",\n",
-    "    cofactors=[\"ATP\", \"NADPH\"],\n",
-    "    ax=plot.one_axes(figsize=(12, 8))[1],\n",
+    "    ax=plot.one_axes(figsize=(8, 5))[1],\n",
+    "    node_size=1000,\n",
     ")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.42.0"
+version = "0.43.0"
 
 [project.optional-dependencies]
 jax = [

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -44,6 +44,7 @@ import pandas as pd
 
 from . import (
     compare,
+    databases,
     distributions,
     experimental,
     fit,
@@ -125,6 +126,7 @@ __all__ = [
     "cartesian_product",
     "compare",
     "configure_default_logging",
+    "databases",
     "distributions",
     "experimental",
     "fit",

--- a/src/mxlpy/databases.py
+++ b/src/mxlpy/databases.py
@@ -1,0 +1,187 @@
+"""Model database integration for BioModels and JWS Online."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import requests
+
+from mxlpy import sbml
+from mxlpy.types import Result
+
+if TYPE_CHECKING:
+    from mxlpy.model import Model
+
+__all__ = [
+    "load_biomodel",
+    "load_jws_model",
+    "search_biomodels",
+    "search_jws_by_reaction",
+    "search_jws_by_species",
+]
+
+_BIOMODELS_BASE = "https://www.ebi.ac.uk/biomodels"
+_JWS_BASE = "https://jjj.bio.vu.nl/rest"
+
+
+def _biomodel_id(accession: int | str) -> str:
+    if isinstance(accession, int):
+        return f"BIOMD{accession:010d}"
+    return accession
+
+
+def _sbml_bytes_to_model(content: bytes) -> Model:
+    with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
+        tmp.write(content)
+        tmp_path = Path(tmp.name)
+    try:
+        return sbml.read(tmp_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def load_biomodel(accession: int | str) -> Result[Model]:
+    """Load a model from BioModels by accession ID or integer index.
+
+    Parameters
+    ----------
+    accession
+        BioModels accession string (e.g. ``"BIOMD0000000012"``) or integer
+        index (e.g. ``12``).
+
+    Returns
+    -------
+    Result[Model]
+        Loaded model, or an exception if the fetch or parse failed.
+
+    Examples
+    --------
+    >>> model = load_biomodel(12).unwrap_or_err()
+    >>> model = load_biomodel("BIOMD0000000012").unwrap_or_err()
+
+    """
+    try:
+        model_id = _biomodel_id(accession)
+        response = requests.get(
+            f"{_BIOMODELS_BASE}/{model_id}/download",
+            params={"filename": f"{model_id}_url.xml"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return Result(_sbml_bytes_to_model(response.content))
+    except Exception as e:  # noqa: BLE001
+        return Result(e)
+
+
+def search_biomodels(query: str, n: int = 10) -> list[dict[str, Any]]:
+    """Search the BioModels database.
+
+    Parameters
+    ----------
+    query
+        Free-text search query (e.g. ``"glycolysis"``).
+    n
+        Maximum number of results to return.
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of model metadata dicts with keys including ``id``, ``name``.
+
+    Examples
+    --------
+    >>> hits = search_biomodels("glycolysis", n=5)
+
+    """
+    response = requests.get(
+        f"{_BIOMODELS_BASE}/search",
+        params={"query": query, "numResults": n, "format": "json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json().get("models", [])
+
+
+def load_jws_model(slug: str) -> Result[Model]:
+    """Load a model from JWS Online by slug identifier.
+
+    Parameters
+    ----------
+    slug
+        JWS Online model slug (e.g. ``"teusink"``).
+
+    Returns
+    -------
+    Result[Model]
+        Loaded model, or an exception if the fetch or parse failed.
+
+    Examples
+    --------
+    >>> model = load_jws_model("teusink").unwrap_or_err()
+
+    """
+    try:
+        response = requests.get(
+            f"{_JWS_BASE}/models/{slug}/sbml",
+            timeout=30,
+        )
+        response.raise_for_status()
+        return Result(_sbml_bytes_to_model(response.content))
+    except Exception as e:  # noqa: BLE001
+        return Result(e)
+
+
+def search_jws_by_species(species: str) -> list[dict[str, Any]]:
+    """Search JWS Online models containing a given species.
+
+    Parameters
+    ----------
+    species
+        Species name or identifier (e.g. ``"atp"``).
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of model metadata dicts.
+
+    Examples
+    --------
+    >>> hits = search_jws_by_species("atp")
+
+    """
+    response = requests.get(
+        f"{_JWS_BASE}/models/",
+        params={"species": species},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def search_jws_by_reaction(reaction: str) -> list[dict[str, Any]]:
+    """Search JWS Online models containing a given reaction.
+
+    Parameters
+    ----------
+    reaction
+        Reaction name or identifier (e.g. ``"pfk"``).
+
+    Returns
+    -------
+    list[dict[str, Any]]
+        List of model metadata dicts.
+
+    Examples
+    --------
+    >>> hits = search_jws_by_reaction("pfk")
+
+    """
+    response = requests.get(
+        f"{_JWS_BASE}/models/",
+        params={"reaction": reaction},
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from mxlpy.databases import (
+    load_biomodel,
+    load_jws_model,
+    search_biomodels,
+    search_jws_by_reaction,
+    search_jws_by_species,
+)
+from mxlpy.model import Model
+from mxlpy.types import Result
+
+SBML_FIXTURE = (
+    Path("tests") / "sbml" / "assets" / "00001" / "00001-sbml-l3v2.xml"
+).read_bytes()
+
+
+def _mock_response(content: bytes) -> MagicMock:
+    mock = MagicMock()
+    mock.content = content
+    mock.raise_for_status.return_value = None
+    return mock
+
+
+def _mock_json_response(data: object) -> MagicMock:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = data
+    return mock
+
+
+def test_load_biomodel_int() -> None:
+    with patch(
+        "mxlpy.databases.requests.get", return_value=_mock_response(SBML_FIXTURE)
+    ) as mock_get:
+        result = load_biomodel(12)
+    assert isinstance(result, Result)
+    assert isinstance(result.unwrap_or_err(), Model)
+    url = mock_get.call_args[0][0]
+    assert "BIOMD0000000012" in url
+
+
+def test_load_biomodel_str() -> None:
+    with patch(
+        "mxlpy.databases.requests.get", return_value=_mock_response(SBML_FIXTURE)
+    ) as mock_get:
+        result = load_biomodel("BIOMD0000000012")
+    assert isinstance(result, Result)
+    assert isinstance(result.unwrap_or_err(), Model)
+    url = mock_get.call_args[0][0]
+    assert "BIOMD0000000012" in url
+
+
+def test_load_biomodel_http_error() -> None:
+    with patch("mxlpy.databases.requests.get", side_effect=requests.HTTPError("404")):
+        result = load_biomodel(12)
+    assert isinstance(result, Result)
+    assert isinstance(result.value, Exception)
+
+
+def test_search_biomodels() -> None:
+    payload = {"models": [{"id": "BIOMD0000000012", "name": "Edelstein"}]}
+    with patch(
+        "mxlpy.databases.requests.get", return_value=_mock_json_response(payload)
+    ):
+        hits = search_biomodels("edelstein", n=1)
+    assert hits == [{"id": "BIOMD0000000012", "name": "Edelstein"}]
+
+
+def test_search_biomodels_empty() -> None:
+    with patch("mxlpy.databases.requests.get", return_value=_mock_json_response({})):
+        hits = search_biomodels("nothing")
+    assert hits == []
+
+
+def test_load_jws_model() -> None:
+    with patch(
+        "mxlpy.databases.requests.get", return_value=_mock_response(SBML_FIXTURE)
+    ):
+        result = load_jws_model("teusink")
+    assert isinstance(result, Result)
+    assert isinstance(result.unwrap_or_err(), Model)
+
+
+def test_load_jws_model_http_error() -> None:
+    with patch("mxlpy.databases.requests.get", side_effect=requests.HTTPError("404")):
+        result = load_jws_model("nonexistent")
+    assert isinstance(result, Result)
+    assert isinstance(result.value, Exception)
+
+
+def test_search_jws_by_species() -> None:
+    payload = [{"slug": "teusink", "name": "Teusink2000"}]
+    with patch(
+        "mxlpy.databases.requests.get", return_value=_mock_json_response(payload)
+    ):
+        hits = search_jws_by_species("atp")
+    assert hits == payload
+
+
+def test_search_jws_by_reaction() -> None:
+    payload = [{"slug": "teusink", "name": "Teusink2000"}]
+    with patch(
+        "mxlpy.databases.requests.get", return_value=_mock_json_response(payload)
+    ):
+        hits = search_jws_by_reaction("pfk")
+    assert hits == payload
+
+
+def test_load_biomodel_raises_on_unwrap_when_error() -> None:
+    with patch(
+        "mxlpy.databases.requests.get", side_effect=requests.ConnectionError("down")
+    ):
+        result = load_biomodel(1)
+    with pytest.raises(requests.ConnectionError):
+        result.unwrap_or_err()


### PR DESCRIPTION
## Summary

- Add `mxlpy.databases` module so notebooks and tutorials can load models by accession ID (`load_biomodel(12)`, `load_jws_model("teusink")`) without bundling SBML files, improving reproducibility.
- HTTP failures are surfaced as `Result[Model]` rather than exceptions, consistent with mxlpy's error-handling philosophy.
- Search functions (`search_biomodels`, `search_jws_by_species`, `search_jws_by_reaction`) return plain dicts matching the external API responses.

## Test plan

- `uv run pytest tests/test_databases.py` — 10 tests covering int/str accession, HTTP errors, search passthrough, and `unwrap_or_err()` propagation; all mocked, no live network calls.
- Verify `from mxlpy import databases` works in a notebook or REPL.

Closes #115