### PR TITLE
feat(dsl): add Model.from_reactions() string-based reaction network DSL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.45.0"
+version = "0.46.0"
 
 [project.optional-dependencies]
 jax = ["diffrax>=0.7.0", "equinox>=0.13", "optax>=0.2.5", "sympy2jax>=0.0.7"]

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -60,7 +60,7 @@ from . import (
     scan,
     units,
 )
-from .dsl import from_reactions
+from .dsl import from_dsl
 from .integrators import DefaultIntegrator, Scipy
 from .integrators.abstract import AbstractIntegrator, IntegratorProtocol
 from .label_map import LabelMapper
@@ -135,7 +135,7 @@ __all__ = [
     "experimental",
     "fit",
     "fns",
-    "from_reactions",
+    "from_dsl",
     "fuzzy",
     "make_protocol",
     "mc",

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -42,10 +42,12 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
+# dsl imported after fns and model to avoid circular-import ordering issues
 from . import (
     compare,
     databases,
     distributions,
+    dsl,
     experimental,
     fit,
     fns,
@@ -58,6 +60,7 @@ from . import (
     scan,
     units,
 )
+from .dsl import from_reactions
 from .integrators import DefaultIntegrator, Scipy
 from .integrators.abstract import AbstractIntegrator, IntegratorProtocol
 from .label_map import LabelMapper
@@ -128,9 +131,11 @@ __all__ = [
     "configure_default_logging",
     "databases",
     "distributions",
+    "dsl",
     "experimental",
     "fit",
     "fns",
+    "from_reactions",
     "fuzzy",
     "make_protocol",
     "mc",

--- a/src/mxlpy/dsl.py
+++ b/src/mxlpy/dsl.py
@@ -1,0 +1,296 @@
+"""String-based DSL for specifying reaction networks."""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import sympy
+
+from mxlpy import fns
+from mxlpy.fns import hill_1s, michaelis_menten_1s
+from mxlpy.model import Model
+
+if TYPE_CHECKING:
+    from mxlpy.types import RateFn
+
+__all__ = ["from_reactions"]
+
+_REVERSIBLE_SEP = re.compile(r"\s*<-->\s*")
+_IRREVERSIBLE_SEP = re.compile(r"\s*-->\s*")
+_SPECIES_TOKEN = re.compile(r"^\s*(\d+)?\s*\*?\s*([A-Za-z_][A-Za-z0-9_]*)\s*$")
+
+
+def _parse_side(side: str) -> dict[str, float]:
+    """Parse one side of a reaction arrow into {species: coefficient}."""
+    side = side.strip()
+    if not side:
+        return {}
+    result: dict[str, float] = {}
+    for token in side.split("+"):
+        m = _SPECIES_TOKEN.match(token)
+        if m is None:
+            msg = f"Cannot parse species token: {token!r}"
+            raise ValueError(msg)
+        coeff = float(m.group(1)) if m.group(1) else 1.0
+        name = m.group(2)
+        result[name] = result.get(name, 0.0) + coeff
+    return result
+
+
+def _net_stoichiometry(
+    reactants: dict[str, float], products: dict[str, float]
+) -> dict[str, float]:
+    names = set(reactants) | set(products)
+    stoich: dict[str, float] = {}
+    for n in names:
+        coeff = products.get(n, 0.0) - reactants.get(n, 0.0)
+        if coeff != 0.0:
+            stoich[n] = coeff
+    return stoich
+
+
+def _consumed(reactants: dict[str, float], products: dict[str, float]) -> list[str]:
+    """Species with negative net stoichiometry (net consumed)."""
+    net = _net_stoichiometry(reactants, products)
+    return [s for s, c in net.items() if c < 0]
+
+
+def _resolve_rate(
+    rate_str: str,
+    reactants: dict[str, float],
+    products: dict[str, float],
+    all_names: set[str],
+) -> tuple[RateFn, list[str]]:
+    """Resolve a rate expression string to a (fn, args) pair."""
+    rate_str = rate_str.strip()
+
+    # --- mm(kcat, Km) shorthand ---
+    m = re.fullmatch(r"mm\s*\(([^)]+)\)", rate_str)
+    if m is not None:
+        param_args = [a.strip() for a in m.group(1).split(",")]
+        consumed = _consumed(reactants, products)
+        if len(consumed) != 1:
+            msg = (
+                f"mm() requires exactly one consumed reactant, "
+                f"got {consumed!r} from rate {rate_str!r}"
+            )
+            raise ValueError(msg)
+        return michaelis_menten_1s, [consumed[0], *param_args]
+
+    # --- hill(v, K, n) shorthand ---
+    m = re.fullmatch(r"hill\s*\(([^)]+)\)", rate_str)
+    if m is not None:
+        param_args = [a.strip() for a in m.group(1).split(",")]
+        consumed = _consumed(reactants, products)
+        if len(consumed) != 1:
+            msg = (
+                f"hill() requires exactly one consumed reactant, "
+                f"got {consumed!r} from rate {rate_str!r}"
+            )
+            raise ValueError(msg)
+        return hill_1s, [consumed[0], *param_args]
+
+    # --- ma(k) shorthand: mass-action over all consumed reactants ---
+    m = re.fullmatch(r"ma\s*\(([^)]+)\)", rate_str)
+    if m is not None:
+        k_name = m.group(1).strip()
+        consumed = _consumed(reactants, products)
+        # Build expression k * s1 * s2 * ...
+        sym_list = [sympy.Symbol(name) for name in [k_name, *consumed]]
+        expr: sympy.Expr = sympy.Mul(*sym_list)
+        arg_names = [k_name, *consumed]
+        fn = sympy.lambdify([sympy.Symbol(a) for a in arg_names], expr, modules="math")
+        return fn, arg_names
+
+    # --- named fn call: fn_name(arg1, arg2, ...) ---
+    m = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)", rate_str)
+    if m is not None:
+        fn_name = m.group(1)
+        fn_obj = getattr(fns, fn_name, None)
+        if fn_obj is not None:
+            arg_names = [a.strip() for a in m.group(2).split(",") if a.strip()]
+            return fn_obj, arg_names
+
+    # --- arbitrary sympy expression ---
+    try:
+        expr = sympy.sympify(rate_str)
+    except sympy.SympifyError as e:
+        msg = f"Cannot parse rate expression: {rate_str!r}"
+        raise ValueError(msg) from e
+
+    free = sorted(str(s) for s in expr.free_symbols)
+    # validate all free symbols are known
+    unknown = [s for s in free if s not in all_names]
+    if unknown:
+        msg = f"Unknown symbols in rate expression {rate_str!r}: {unknown}"
+        raise ValueError(msg)
+    fn = sympy.lambdify([sympy.Symbol(s) for s in free], expr, modules="math")
+    return fn, free
+
+
+def _first_top_level_comma(s: str) -> int:
+    """Return index of first comma not inside parentheses, or -1."""
+    depth = 0
+    for i, ch in enumerate(s):
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            return i
+    return -1
+
+
+def from_reactions(
+    network: str,
+    *,
+    species: dict[str, float],
+    parameters: dict[str, float],
+) -> Model:
+    """Build a Model from a string-based reaction network DSL.
+
+    Each non-empty, non-comment line has the form::
+
+        rate_expr, reactants --> products
+        (fwd_expr, rev_expr), reactants <--> products   # reversible
+
+    Rate expression shorthands:
+
+    - ``mm(kcat, Km)``  — Michaelis-Menten; substrate inferred from single consumed reactant
+    - ``hill(v, K, n)`` — Hill kinetics; substrate inferred from single consumed reactant
+    - ``ma(k)``         — mass-action over all consumed reactants
+    - ``fn_name(...)``  — any function defined in ``mxlpy.fns``
+    - anything else     — treated as a SymPy expression; free symbols become args
+
+    Parameters
+    ----------
+    network
+        Multi-line string describing the reaction network.
+    species
+        Initial conditions for every species that appears in the network.
+        Raises ``ValueError`` for species not listed here.
+    parameters
+        Values for every parameter that appears in rate expressions.
+        Raises ``ValueError`` for parameters not listed here.
+
+    Returns
+    -------
+    Model
+        Fully constructed model.
+
+    Examples
+    --------
+    >>> model = from_reactions(
+    ...     "k1, A --> B",
+    ...     species={"A": 1.0, "B": 0.0},
+    ...     parameters={"k1": 0.1},
+    ... )
+
+    """
+    all_names: set[str] = set(species) | set(parameters)
+
+    model = Model()
+    model.add_variables(species)
+    model.add_parameters(parameters)
+
+    reaction_counter = 0
+
+    for raw_line in network.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        # Split on first comma NOT inside parentheses
+        comma_idx = _first_top_level_comma(line)
+        if comma_idx == -1:
+            msg = f"Missing comma separator in line: {line!r}"
+            raise ValueError(msg)
+        rate_part = line[:comma_idx].strip()
+        rxn_part = line[comma_idx + 1 :].strip()
+
+        # Detect reversible
+        is_reversible = bool(_REVERSIBLE_SEP.search(rxn_part))
+
+        reaction_counter += 1
+        r_idx = reaction_counter
+
+        if is_reversible:
+            # rate_part must be (fwd, rev)
+            rev_m = re.fullmatch(r"\(\s*([^,]+)\s*,\s*([^)]+)\s*\)", rate_part)
+            if rev_m is None:
+                msg = (
+                    f"Reversible reaction requires rate tuple (fwd, rev), "
+                    f"got: {rate_part!r}"
+                )
+                raise ValueError(msg)
+            fwd_rate_str = rev_m.group(1).strip()
+            rev_rate_str = rev_m.group(2).strip()
+
+            parts = _REVERSIBLE_SEP.split(rxn_part, maxsplit=1)
+            reactants = _parse_side(parts[0])
+            products = _parse_side(parts[1])
+
+            _validate_species(reactants, products, species)
+
+            stoich_fwd = _net_stoichiometry(reactants, products)
+            stoich_rev = {k: -v for k, v in stoich_fwd.items()}
+
+            fwd_fn, fwd_args = _resolve_rate(
+                fwd_rate_str, reactants, products, all_names
+            )
+            _validate_args(fwd_args, all_names, fwd_rate_str)
+
+            # For reverse, swap reactant/product perspective
+            rev_fn, rev_args = _resolve_rate(
+                rev_rate_str, products, reactants, all_names
+            )
+            _validate_args(rev_args, all_names, rev_rate_str)
+
+            model.add_reaction(
+                f"r{r_idx}_fwd", fwd_fn, args=fwd_args, stoichiometry=stoich_fwd
+            )
+            model.add_reaction(
+                f"r{r_idx}_rev", rev_fn, args=rev_args, stoichiometry=stoich_rev
+            )
+
+        else:
+            parts = _IRREVERSIBLE_SEP.split(rxn_part, maxsplit=1)
+            if len(parts) != 2:  # noqa: PLR2004
+                msg = f"Could not parse reaction: {rxn_part!r}"
+                raise ValueError(msg)
+            reactants = _parse_side(parts[0])
+            products = _parse_side(parts[1])
+
+            _validate_species(reactants, products, species)
+
+            stoich = _net_stoichiometry(reactants, products)
+            fn, args = _resolve_rate(rate_part, reactants, products, all_names)
+            _validate_args(args, all_names, rate_part)
+
+            model.add_reaction(f"r{r_idx}", fn, args=args, stoichiometry=stoich)
+
+    return model
+
+
+def _validate_species(
+    reactants: dict[str, float],
+    products: dict[str, float],
+    species: dict[str, float],
+) -> None:
+    all_rxn_species = set(reactants) | set(products)
+    missing = all_rxn_species - set(species)
+    if missing:
+        msg = f"Species in reaction not found in species dict: {sorted(missing)}"
+        raise ValueError(msg)
+
+
+def _validate_args(
+    args: list[str],
+    all_names: set[str],
+    rate_str: str,
+) -> None:
+    missing = [a for a in args if a not in all_names]
+    if missing:
+        msg = f"Unknown symbols {missing!r} in rate expression {rate_str!r}"
+        raise ValueError(msg)

--- a/src/mxlpy/dsl.py
+++ b/src/mxlpy/dsl.py
@@ -9,12 +9,12 @@ import sympy
 
 from mxlpy import fns
 from mxlpy.fns import hill_1s, michaelis_menten_1s
-from mxlpy.model import Model
 
 if TYPE_CHECKING:
+    from mxlpy.model import Model
     from mxlpy.types import RateFn
 
-__all__ = ["from_reactions"]
+__all__ = ["from_dsl"]
 
 _REVERSIBLE_SEP = re.compile(r"\s*<-->\s*")
 _IRREVERSIBLE_SEP = re.compile(r"\s*-->\s*")
@@ -22,7 +22,7 @@ _SPECIES_TOKEN = re.compile(r"^\s*(\d+)?\s*\*?\s*([A-Za-z_][A-Za-z0-9_]*)\s*$")
 
 
 def _parse_side(side: str) -> dict[str, float]:
-    """Parse one side of a reaction arrow into {species: coefficient}."""
+    """Parse one side of a reaction arrow into {variable: coefficient}."""
     side = side.strip()
     if not side:
         return {}
@@ -30,7 +30,7 @@ def _parse_side(side: str) -> dict[str, float]:
     for token in side.split("+"):
         m = _SPECIES_TOKEN.match(token)
         if m is None:
-            msg = f"Cannot parse species token: {token!r}"
+            msg = f"Cannot parse variable token: {token!r}"
             raise ValueError(msg)
         coeff = float(m.group(1)) if m.group(1) else 1.0
         name = m.group(2)
@@ -142,12 +142,36 @@ def _first_top_level_comma(s: str) -> int:
     return -1
 
 
-def from_reactions(
+def _validate_variables(
+    reactants: dict[str, float],
+    products: dict[str, float],
+    variables: dict[str, float],
+) -> None:
+    all_rxn_vars = set(reactants) | set(products)
+    missing = all_rxn_vars - set(variables)
+    if missing:
+        msg = f"Species in reaction not found in variables dict: {sorted(missing)}"
+        raise ValueError(msg)
+
+
+def _validate_args(
+    args: list[str],
+    all_names: set[str],
+    rate_str: str,
+) -> None:
+    missing = [a for a in args if a not in all_names]
+    if missing:
+        msg = f"Unknown symbols {missing!r} in rate expression {rate_str!r}"
+        raise ValueError(msg)
+
+
+def from_dsl[T: Model](
+    model: T,
     network: str,
     *,
-    species: dict[str, float],
+    variables: dict[str, float],
     parameters: dict[str, float],
-) -> Model:
+) -> T:
     """Build a Model from a string-based reaction network DSL.
 
     Each non-empty, non-comment line has the form::
@@ -167,9 +191,9 @@ def from_reactions(
     ----------
     network
         Multi-line string describing the reaction network.
-    species
-        Initial conditions for every species that appears in the network.
-        Raises ``ValueError`` for species not listed here.
+    variables
+        Initial conditions for every variable that appears in the network.
+        Raises ``ValueError`` for variables not listed here.
     parameters
         Values for every parameter that appears in rate expressions.
         Raises ``ValueError`` for parameters not listed here.
@@ -181,17 +205,16 @@ def from_reactions(
 
     Examples
     --------
-    >>> model = from_reactions(
+    >>> model = model.add_reactions_from_dsl(
     ...     "k1, A --> B",
-    ...     species={"A": 1.0, "B": 0.0},
+    ...     variables={"A": 1.0, "B": 0.0},
     ...     parameters={"k1": 0.1},
     ... )
 
     """
-    all_names: set[str] = set(species) | set(parameters)
+    all_names: set[str] = set(variables) | set(parameters)
 
-    model = Model()
-    model.add_variables(species)
+    model.add_variables(variables)
     model.add_parameters(parameters)
 
     reaction_counter = 0
@@ -231,7 +254,7 @@ def from_reactions(
             reactants = _parse_side(parts[0])
             products = _parse_side(parts[1])
 
-            _validate_species(reactants, products, species)
+            _validate_variables(reactants, products, variables)
 
             stoich_fwd = _net_stoichiometry(reactants, products)
             stoich_rev = {k: -v for k, v in stoich_fwd.items()}
@@ -262,7 +285,7 @@ def from_reactions(
             reactants = _parse_side(parts[0])
             products = _parse_side(parts[1])
 
-            _validate_species(reactants, products, species)
+            _validate_variables(reactants, products, variables)
 
             stoich = _net_stoichiometry(reactants, products)
             fn, args = _resolve_rate(rate_part, reactants, products, all_names)
@@ -271,26 +294,3 @@ def from_reactions(
             model.add_reaction(f"r{r_idx}", fn, args=args, stoichiometry=stoich)
 
     return model
-
-
-def _validate_species(
-    reactants: dict[str, float],
-    products: dict[str, float],
-    species: dict[str, float],
-) -> None:
-    all_rxn_species = set(reactants) | set(products)
-    missing = all_rxn_species - set(species)
-    if missing:
-        msg = f"Species in reaction not found in species dict: {sorted(missing)}"
-        raise ValueError(msg)
-
-
-def _validate_args(
-    args: list[str],
-    all_names: set[str],
-    rate_str: str,
-) -> None:
-    missing = [a for a in args if a not in all_names]
-    if missing:
-        msg = f"Unknown symbols {missing!r} in rate expression {rate_str!r}"
-        raise ValueError(msg)

--- a/src/mxlpy/fns.py
+++ b/src/mxlpy/fns.py
@@ -7,6 +7,7 @@ __all__ = [
     "constant",
     "diffusion_1s_1p",
     "div",
+    "hill_1s",
     "mass_action_1s",
     "mass_action_1s_1p",
     "mass_action_2s",
@@ -637,6 +638,41 @@ def michaelis_menten_3s(
     return (
         vmax * s1 * s2 * s3 / (s1 * s2 + km1 * s2 * s3 + km2 * s1 * s3 + km3 * s1 * s2)
     )
+
+
+def hill_1s(s: float, v: float, K: float, n: float) -> float:  # noqa: N803
+    """Calculate Hill kinetics rate for one substrate.
+
+    Rate = v * s^n / (K^n + s^n)
+
+    Parameters
+    ----------
+    s
+        Substrate concentration
+    v
+        Maximum reaction velocity
+    K
+        Half-saturation constant
+    n
+        Hill coefficient (cooperativity)
+
+    Returns
+    -------
+    Float
+        Reaction rate
+
+    Examples
+    --------
+    >>> hill_1s(1.0, 10.0, 1.0, 1.0)  # Hill-1 reduces to Michaelis-Menten
+    5.0
+    >>> hill_1s(1.0, 10.0, 1.0, 2.0)  # Cooperative binding
+    5.0
+    >>> hill_1s(2.0, 10.0, 1.0, 2.0)
+    8.0
+
+    """
+    sn = s**n
+    return v * sn / (K**n + sn)
 
 
 ###############################################################################

--- a/src/mxlpy/model.py
+++ b/src/mxlpy/model.py
@@ -2795,3 +2795,35 @@ class Model:
             readouts=self._readouts,
             time_unit=time_unit,
         )
+
+    @classmethod
+    def from_reactions(
+        cls,
+        network: str,
+        *,
+        species: dict[str, float],
+        parameters: dict[str, float],
+    ) -> Model:
+        """Build a Model from a string-based reaction network DSL.
+
+        Delegates to :func:`mxlpy.dsl.from_reactions`. See that function for
+        full documentation and supported syntax.
+
+        Parameters
+        ----------
+        network
+            Multi-line string describing the reaction network.
+        species
+            Initial conditions keyed by species name.
+        parameters
+            Parameter values keyed by parameter name.
+
+        Returns
+        -------
+        Model
+            Fully constructed model.
+
+        """
+        from mxlpy.dsl import from_reactions
+
+        return from_reactions(network, species=species, parameters=parameters)

--- a/src/mxlpy/model.py
+++ b/src/mxlpy/model.py
@@ -20,6 +20,7 @@ import sympy
 from wadler_lindig import pformat
 
 from mxlpy import _topo, fns
+from mxlpy.dsl import from_dsl
 from mxlpy.meta.source_tools import fn_to_sympy_expr
 from mxlpy.meta.sympy_tools import (
     list_of_symbols,
@@ -1666,7 +1667,7 @@ class Model:
         args
             A list of arguments for the reaction function.
         stoichiometry
-            The stoichiometry of the reaction, mapping species to their coefficients.
+            The stoichiometry of the reaction, mapping variables to their coefficients.
         unit
             Unit of the rate
 
@@ -1804,6 +1805,39 @@ class Model:
     #         compound=compound,
     #         value=self.stoichiometries[rate_name][compound] * scale,
     #     )
+
+    ##########################################################################
+    # DSLs
+    ##########################################################################
+
+    def add_reactions_from_dsl(
+        self,
+        network: str,
+        *,
+        variables: dict[str, float],
+        parameters: dict[str, float],
+    ) -> Self:
+        """Build a Model from a string-based reaction network DSL.
+
+        Delegates to :func:`mxlpy.dsl.from_reactions`. See that function for
+        full documentation and supported syntax.
+
+        Parameters
+        ----------
+        network
+            Multi-line string describing the reaction network.
+        variables
+            Initial conditions keyed by variable name.
+        parameters
+            Parameter values keyed by parameter name.
+
+        Returns
+        -------
+        Model
+            Fully constructed model.
+
+        """
+        return from_dsl(self, network, variables=variables, parameters=parameters)
 
     ##########################################################################
     # Readouts
@@ -2487,7 +2521,7 @@ class Model:
         Parameters
         ----------
         variables
-            A dictionary where keys are species names and values are their concentrations.
+            A dictionary where keys are variable names and values are their concentrations.
         time
             The time at which to calculate the fluxes. Defaults to 0.0.
 
@@ -2795,35 +2829,3 @@ class Model:
             readouts=self._readouts,
             time_unit=time_unit,
         )
-
-    @classmethod
-    def from_reactions(
-        cls,
-        network: str,
-        *,
-        species: dict[str, float],
-        parameters: dict[str, float],
-    ) -> Model:
-        """Build a Model from a string-based reaction network DSL.
-
-        Delegates to :func:`mxlpy.dsl.from_reactions`. See that function for
-        full documentation and supported syntax.
-
-        Parameters
-        ----------
-        network
-            Multi-line string describing the reaction network.
-        species
-            Initial conditions keyed by species name.
-        parameters
-            Parameter values keyed by parameter name.
-
-        Returns
-        -------
-        Model
-            Fully constructed model.
-
-        """
-        from mxlpy.dsl import from_reactions
-
-        return from_reactions(network, species=species, parameters=parameters)

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -5,14 +5,15 @@ from __future__ import annotations
 import pytest
 
 from mxlpy import Model
-from mxlpy.dsl import from_reactions
+from mxlpy.dsl import from_dsl
 from mxlpy.fns import hill_1s, mass_action_1s, michaelis_menten_1s
 
 
 def test_simple_irreversible() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "k1, A --> B",
-        species={"A": 1.0, "B": 0.0},
+        variables={"A": 1.0, "B": 0.0},
         parameters={"k1": 0.1},
     )
     assert set(model.get_reaction_names()) == {"r1"}
@@ -20,30 +21,33 @@ def test_simple_irreversible() -> None:
 
 
 def test_reversible_reaction() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "(k2, k3), C <--> D",
-        species={"C": 1.0, "D": 0.0},
+        variables={"C": 1.0, "D": 0.0},
         parameters={"k2": 0.05, "k3": 0.02},
     )
     assert set(model.get_reaction_names()) == {"r1_fwd", "r1_rev"}
 
 
 def test_sequential_naming() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         """
         k1, A --> B
         k2, B --> C
         """,
-        species={"A": 1.0, "B": 0.0, "C": 0.0},
+        variables={"A": 1.0, "B": 0.0, "C": 0.0},
         parameters={"k1": 0.1, "k2": 0.2},
     )
     assert set(model.get_reaction_names()) == {"r1", "r2"}
 
 
 def test_mm_shorthand() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "mm(kcat, Km), S --> P",
-        species={"S": 2.0, "P": 0.0},
+        variables={"S": 2.0, "P": 0.0},
         parameters={"kcat": 1.0, "Km": 0.5},
     )
     assert "r1" in model.get_reaction_names()
@@ -53,9 +57,10 @@ def test_mm_shorthand() -> None:
 
 
 def test_hill_shorthand() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "hill(v, K, n), A --> B",
-        species={"A": 1.0, "B": 0.0},
+        variables={"A": 1.0, "B": 0.0},
         parameters={"v": 1.0, "K": 0.3, "n": 2.0},
     )
     rxn = model._reactions["r1"]
@@ -64,9 +69,10 @@ def test_hill_shorthand() -> None:
 
 
 def test_ma_shorthand() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "ma(k1), A + B --> C",
-        species={"A": 1.0, "B": 0.5, "C": 0.0},
+        variables={"A": 1.0, "B": 0.5, "C": 0.0},
         parameters={"k1": 0.1},
     )
     rxn = model._reactions["r1"]
@@ -75,9 +81,10 @@ def test_ma_shorthand() -> None:
 
 
 def test_arbitrary_expression() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "k_deg * X, X -->",
-        species={"X": 1.0},
+        variables={"X": 1.0},
         parameters={"k_deg": 0.1},
     )
     rxn = model._reactions["r1"]
@@ -85,9 +92,10 @@ def test_arbitrary_expression() -> None:
 
 
 def test_named_fns_lookup() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "mass_action_1s(A, k1), A --> B",
-        species={"A": 1.0, "B": 0.0},
+        variables={"A": 1.0, "B": 0.0},
         parameters={"k1": 0.1},
     )
     rxn = model._reactions["r1"]
@@ -96,9 +104,10 @@ def test_named_fns_lookup() -> None:
 
 
 def test_degradation_empty_product() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "k_deg * X, X -->",
-        species={"X": 2.0},
+        variables={"X": 2.0},
         parameters={"k_deg": 0.5},
     )
     stoich = model._reactions["r1"].stoichiometry
@@ -106,9 +115,10 @@ def test_degradation_empty_product() -> None:
 
 
 def test_production_empty_reactant() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "ma(k_syn), --> Y",
-        species={"Y": 0.0},
+        variables={"Y": 0.0},
         parameters={"k_syn": 0.2},
     )
     stoich = model._reactions["r1"].stoichiometry
@@ -116,9 +126,10 @@ def test_production_empty_reactant() -> None:
 
 
 def test_stoichiometric_coefficient() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         "k1, 2A + B --> C",
-        species={"A": 2.0, "B": 1.0, "C": 0.0},
+        variables={"A": 2.0, "B": 1.0, "C": 0.0},
         parameters={"k1": 0.1},
     )
     stoich = model._reactions["r1"].stoichiometry
@@ -128,13 +139,14 @@ def test_stoichiometric_coefficient() -> None:
 
 
 def test_comment_lines_ignored() -> None:
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         """
         # this is a comment
         k1, A --> B
         # another comment
         """,
-        species={"A": 1.0, "B": 0.0},
+        variables={"A": 1.0, "B": 0.0},
         parameters={"k1": 0.1},
     )
     assert model.get_reaction_names() == ["r1"]
@@ -142,52 +154,58 @@ def test_comment_lines_ignored() -> None:
 
 def test_missing_species_raises() -> None:
     with pytest.raises(ValueError, match="Species"):
-        from_reactions(
+        from_dsl(
+            Model(),
             "k1, A --> B",
-            species={"A": 1.0},  # B missing
+            variables={"A": 1.0},  # B missing
             parameters={"k1": 0.1},
         )
 
 
 def test_missing_parameter_raises() -> None:
     with pytest.raises(ValueError, match="Unknown"):
-        from_reactions(
+        from_dsl(
+            Model(),
             "k1 * A, A --> B",
-            species={"A": 1.0, "B": 0.0},
+            variables={"A": 1.0, "B": 0.0},
             parameters={},  # k1 missing
         )
 
 
 def test_mm_ambiguous_substrate_raises() -> None:
     with pytest.raises(ValueError, match="mm\\(\\) requires exactly one"):
-        from_reactions(
+        from_dsl(
+            Model(),
             "mm(kcat, Km), A + B --> C",
-            species={"A": 1.0, "B": 1.0, "C": 0.0},
+            variables={"A": 1.0, "B": 1.0, "C": 0.0},
             parameters={"kcat": 1.0, "Km": 0.5},
         )
 
 
 def test_hill_ambiguous_substrate_raises() -> None:
     with pytest.raises(ValueError, match="hill\\(\\) requires exactly one"):
-        from_reactions(
+        from_dsl(
+            Model(),
             "hill(v, K, n), A + B --> C",
-            species={"A": 1.0, "B": 1.0, "C": 0.0},
+            variables={"A": 1.0, "B": 1.0, "C": 0.0},
             parameters={"v": 1.0, "K": 0.3, "n": 2.0},
         )
 
 
 def test_reversible_without_tuple_raises() -> None:
     with pytest.raises(ValueError, match="tuple"):
-        from_reactions(
+        from_dsl(
+            Model(),
             "k1, C <--> D",
-            species={"C": 1.0, "D": 0.0},
+            variables={"C": 1.0, "D": 0.0},
             parameters={"k1": 0.05},
         )
 
 
 def test_full_example() -> None:
     """Smoke test: the canonical example from the issue must build without error."""
-    model = from_reactions(
+    model = from_dsl(
+        Model(),
         """
         k1,              A + B --> C
         (k2, k3),        C <--> D
@@ -196,7 +214,7 @@ def test_full_example() -> None:
         k_deg * X,       X -->
         ma(k_syn),       --> Y
         """,
-        species={
+        variables={
             "A": 1.0,
             "B": 0.5,
             "C": 0.0,
@@ -225,9 +243,10 @@ def test_full_example() -> None:
 
 
 def test_model_from_reactions_classmethod() -> None:
-    model = Model.from_reactions(
+    model = Model.add_reactions_from_dsl(
+        Model(),
         "k1, A --> B",
-        species={"A": 1.0, "B": 0.0},
+        variables={"A": 1.0, "B": 0.0},
         parameters={"k1": 0.1},
     )
     assert "r1" in model.get_reaction_names()

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,0 +1,233 @@
+"""Tests for the reaction-network DSL."""
+
+from __future__ import annotations
+
+import pytest
+
+from mxlpy import Model
+from mxlpy.dsl import from_reactions
+from mxlpy.fns import hill_1s, mass_action_1s, michaelis_menten_1s
+
+
+def test_simple_irreversible() -> None:
+    model = from_reactions(
+        "k1, A --> B",
+        species={"A": 1.0, "B": 0.0},
+        parameters={"k1": 0.1},
+    )
+    assert set(model.get_reaction_names()) == {"r1"}
+    assert set(model.get_variable_names()) == {"A", "B"}
+
+
+def test_reversible_reaction() -> None:
+    model = from_reactions(
+        "(k2, k3), C <--> D",
+        species={"C": 1.0, "D": 0.0},
+        parameters={"k2": 0.05, "k3": 0.02},
+    )
+    assert set(model.get_reaction_names()) == {"r1_fwd", "r1_rev"}
+
+
+def test_sequential_naming() -> None:
+    model = from_reactions(
+        """
+        k1, A --> B
+        k2, B --> C
+        """,
+        species={"A": 1.0, "B": 0.0, "C": 0.0},
+        parameters={"k1": 0.1, "k2": 0.2},
+    )
+    assert set(model.get_reaction_names()) == {"r1", "r2"}
+
+
+def test_mm_shorthand() -> None:
+    model = from_reactions(
+        "mm(kcat, Km), S --> P",
+        species={"S": 2.0, "P": 0.0},
+        parameters={"kcat": 1.0, "Km": 0.5},
+    )
+    assert "r1" in model.get_reaction_names()
+    rxn = model._reactions["r1"]
+    assert rxn.fn is michaelis_menten_1s
+    assert rxn.args == ["S", "kcat", "Km"]
+
+
+def test_hill_shorthand() -> None:
+    model = from_reactions(
+        "hill(v, K, n), A --> B",
+        species={"A": 1.0, "B": 0.0},
+        parameters={"v": 1.0, "K": 0.3, "n": 2.0},
+    )
+    rxn = model._reactions["r1"]
+    assert rxn.fn is hill_1s
+    assert rxn.args == ["A", "v", "K", "n"]
+
+
+def test_ma_shorthand() -> None:
+    model = from_reactions(
+        "ma(k1), A + B --> C",
+        species={"A": 1.0, "B": 0.5, "C": 0.0},
+        parameters={"k1": 0.1},
+    )
+    rxn = model._reactions["r1"]
+    result = rxn.fn(*[model.get_parameter_values()["k1"], 1.0, 0.5])
+    assert abs(result - 0.05) < 1e-9
+
+
+def test_arbitrary_expression() -> None:
+    model = from_reactions(
+        "k_deg * X, X -->",
+        species={"X": 1.0},
+        parameters={"k_deg": 0.1},
+    )
+    rxn = model._reactions["r1"]
+    assert set(rxn.args) == {"X", "k_deg"}
+
+
+def test_named_fns_lookup() -> None:
+    model = from_reactions(
+        "mass_action_1s(A, k1), A --> B",
+        species={"A": 1.0, "B": 0.0},
+        parameters={"k1": 0.1},
+    )
+    rxn = model._reactions["r1"]
+    assert rxn.fn is mass_action_1s
+    assert rxn.args == ["A", "k1"]
+
+
+def test_degradation_empty_product() -> None:
+    model = from_reactions(
+        "k_deg * X, X -->",
+        species={"X": 2.0},
+        parameters={"k_deg": 0.5},
+    )
+    stoich = model._reactions["r1"].stoichiometry
+    assert "X" in stoich
+
+
+def test_production_empty_reactant() -> None:
+    model = from_reactions(
+        "ma(k_syn), --> Y",
+        species={"Y": 0.0},
+        parameters={"k_syn": 0.2},
+    )
+    stoich = model._reactions["r1"].stoichiometry
+    assert "Y" in stoich
+
+
+def test_stoichiometric_coefficient() -> None:
+    model = from_reactions(
+        "k1, 2A + B --> C",
+        species={"A": 2.0, "B": 1.0, "C": 0.0},
+        parameters={"k1": 0.1},
+    )
+    stoich = model._reactions["r1"].stoichiometry
+    assert stoich["A"] == -2.0
+    assert stoich["B"] == -1.0
+    assert stoich["C"] == 1.0
+
+
+def test_comment_lines_ignored() -> None:
+    model = from_reactions(
+        """
+        # this is a comment
+        k1, A --> B
+        # another comment
+        """,
+        species={"A": 1.0, "B": 0.0},
+        parameters={"k1": 0.1},
+    )
+    assert model.get_reaction_names() == ["r1"]
+
+
+def test_missing_species_raises() -> None:
+    with pytest.raises(ValueError, match="Species"):
+        from_reactions(
+            "k1, A --> B",
+            species={"A": 1.0},  # B missing
+            parameters={"k1": 0.1},
+        )
+
+
+def test_missing_parameter_raises() -> None:
+    with pytest.raises(ValueError, match="Unknown"):
+        from_reactions(
+            "k1 * A, A --> B",
+            species={"A": 1.0, "B": 0.0},
+            parameters={},  # k1 missing
+        )
+
+
+def test_mm_ambiguous_substrate_raises() -> None:
+    with pytest.raises(ValueError, match="mm\\(\\) requires exactly one"):
+        from_reactions(
+            "mm(kcat, Km), A + B --> C",
+            species={"A": 1.0, "B": 1.0, "C": 0.0},
+            parameters={"kcat": 1.0, "Km": 0.5},
+        )
+
+
+def test_hill_ambiguous_substrate_raises() -> None:
+    with pytest.raises(ValueError, match="hill\\(\\) requires exactly one"):
+        from_reactions(
+            "hill(v, K, n), A + B --> C",
+            species={"A": 1.0, "B": 1.0, "C": 0.0},
+            parameters={"v": 1.0, "K": 0.3, "n": 2.0},
+        )
+
+
+def test_reversible_without_tuple_raises() -> None:
+    with pytest.raises(ValueError, match="tuple"):
+        from_reactions(
+            "k1, C <--> D",
+            species={"C": 1.0, "D": 0.0},
+            parameters={"k1": 0.05},
+        )
+
+
+def test_full_example() -> None:
+    """Smoke test: the canonical example from the issue must build without error."""
+    model = from_reactions(
+        """
+        k1,              A + B --> C
+        (k2, k3),        C <--> D
+        mm(kcat, Km),    E + S --> E + P
+        hill(v, K, n),   A --> B
+        k_deg * X,       X -->
+        ma(k_syn),       --> Y
+        """,
+        species={
+            "A": 1.0,
+            "B": 0.5,
+            "C": 0.0,
+            "D": 0.0,
+            "E": 0.1,
+            "S": 2.0,
+            "P": 0.0,
+            "X": 1.0,
+            "Y": 0.0,
+        },
+        parameters={
+            "k1": 0.1,
+            "k2": 0.05,
+            "k3": 0.02,
+            "kcat": 1.0,
+            "Km": 0.5,
+            "v": 1.0,
+            "K": 0.3,
+            "n": 2.0,
+            "k_deg": 0.1,
+            "k_syn": 0.2,
+        },
+    )
+    expected_rxns = {"r1", "r2_fwd", "r2_rev", "r3", "r4", "r5", "r6"}
+    assert set(model.get_reaction_names()) == expected_rxns
+
+
+def test_model_from_reactions_classmethod() -> None:
+    model = Model.from_reactions(
+        "k1, A --> B",
+        species={"A": 1.0, "B": 0.0},
+        parameters={"k1": 0.1},
+    )
+    assert "r1" in model.get_reaction_names()


### PR DESCRIPTION
## Summary

- Adds `Model.from_reactions()` and `mxlpy.from_reactions()` — a string-based DSL that compiles chemical equation notation directly into the existing `Model` API, making large networks diffable and easier to read than chained `add_reaction()` calls.
- Introduces `hill_1s(s, v, K, n)` to `fns.py` (missing from the library until now); adds `mm()`, `hill()`, `ma()` shorthands that resolve to named functions where possible and fall back to `sympy.lambdify` for arbitrary expressions.
- All design is validated eagerly: missing species or unrecognised symbols in rate expressions raise `ValueError` at parse time, not at simulation time.

## Test plan

- Run `uv run pytest tests/test_dsl.py -v` — 19 tests covering irreversible/reversible reactions, all rate shorthands, stoichiometric coefficients, comments, empty reactant/product sides, error paths, and the canonical full example from the issue.
- Verify no regressions: `uv run pytest --disable-warnings -q` — pre-existing failures are unrelated to this change.

Closes #121