### PR TITLE
feat(mca): add supply-demand rate characteristic analysis

### DIFF
--- a/docs/mca.ipynb
+++ b/docs/mca.ipynb
@@ -208,6 +208,43 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Supply-demand rate characteristics\n",
+    "\n",
+    "Where the analyses above are *local* (a small perturbation around a single state), **rate characteristics** show the *global* picture: how the reactions that produce and consume a metabolite respond across its whole concentration range.\n",
+    "\n",
+    "`rate_characteristics` clamps a chosen variable to a logarithmically spaced range around its steady-state concentration, recomputes the steady state of the remaining variables at each point, and collects the fluxes of the reactions that **produce** it (*supply*) and **consume** it (*demand*). The intersection of total supply and total demand is the steady state — plotting both curves places that operating point in the context of the full range.\n",
+    "\n",
+    "Reactions are classified structurally from the stoichiometry: a positive coefficient marks a supply reaction, a negative one a demand reaction. The scan spans `[ss / min_factor, ss * max_factor]` with `n_points` log-spaced samples.\n",
+    "\n",
+    "The result exposes:\n",
+    "\n",
+    "| Attribute / method | Description |\n",
+    "|---|---|\n",
+    "| `supply_fluxes` / `demand_fluxes` | Per-reaction fluxes vs. the clamped concentration (one column per reaction) |\n",
+    "| `total_supply` / `total_demand` | Summed supply / demand flux |\n",
+    "| `steady_state_conc` | Concentration of the variable at the original steady state |\n",
+    "| `plot_supply_demand()` | Total supply and demand on a single log-log axis |\n",
+    "| `plot()` | Three-panel summary: total supply vs. demand, per-reaction supply, per-reaction demand |\n",
+    "\n",
+    "Here we scan `F6P`, which is produced by two reactions (`v3`, `v5`) and consumed by one (`v4`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rc = mca.rate_characteristics(get_upper_glycolysis(), \"F6P\")\n",
+    "\n",
+    "_ = rc.plot()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<div style=\"color: #ffffff; background-color: #04AA6D; padding: 3rem 1rem 3rem 1rem; box-sizing: border-box\">\n",
     "    <h2>First finish line</h2>\n",
     "    With that you now know most of what you will need from a day-to-day basis about metabolic control analysis in mxlpy.\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.46.0"
+version = "0.47.0"
 
 [project.optional-dependencies]
 jax = ["diffrax>=0.7.0", "equinox>=0.13", "optax>=0.2.5", "sympy2jax>=0.0.7"]

--- a/src/mxlpy/mca.py
+++ b/src/mxlpy/mca.py
@@ -17,6 +17,7 @@ Mathematical Background:
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 from functools import partial
 from typing import TYPE_CHECKING, Any
@@ -26,22 +27,28 @@ import pandas as pd
 from wadler_lindig import pformat
 
 from mxlpy.parallel import parallelise
-from mxlpy.scan import _steady_state_worker
+from mxlpy.plot import _default_fig_ax, _default_fig_axs
+from mxlpy.scan import _steady_state_worker, steady_state
+from mxlpy.simulator import Simulator
 from mxlpy.symbolic.symbolic_model import to_symbolic_model
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from matplotlib.axes import Axes
     from numpy.typing import NDArray
 
     from mxlpy.integrators import IntegratorType
     from mxlpy.model import Model
+    from mxlpy.plot import FigAx, FigAxs
 
 __all__ = [
+    "RateCharacteristics",
     "ResponseCoefficients",
     "ResponseCoefficientsByPars",
     "SteadyStateStability",
     "parameter_elasticities",
+    "rate_characteristics",
     "response_coefficients",
     "steady_state_stability",
     "variable_elasticities",
@@ -472,4 +479,227 @@ def steady_state_stability(
         is_stable=is_stable,
         has_oscillatory=has_oscillatory,
         classification=classification,
+    )
+
+
+###############################################################################
+# Supply-demand rate characteristics
+###############################################################################
+
+
+@dataclass(kw_only=True, slots=True)
+class RateCharacteristics:
+    """Supply and demand rate characteristics for a single variable.
+
+    Holds the supply and demand fluxes obtained by clamping a variable to a
+    range of concentrations and re-computing the steady state at each point.
+    The original steady-state concentration is retained so it can be marked on
+    the characteristic plots.
+
+    Attributes
+    ----------
+    supply_fluxes
+        Fluxes of reactions that produce the variable, indexed by the scanned
+        concentration. One column per supply reaction; empty if the variable is
+        never produced.
+    demand_fluxes
+        Fluxes of reactions that consume the variable, indexed by the scanned
+        concentration. One column per demand reaction; empty if the variable is
+        never consumed.
+    steady_state_conc
+        Concentration of the variable at the original steady state.
+
+    """
+
+    supply_fluxes: pd.DataFrame
+    demand_fluxes: pd.DataFrame
+    steady_state_conc: float
+
+    def __repr__(self) -> str:
+        """Return default representation."""
+        return pformat(self)
+
+    @property
+    def total_supply(self) -> pd.Series:
+        """Total supply flux (sum over all supply reactions)."""
+        return self.supply_fluxes.sum(axis=1)
+
+    @property
+    def total_demand(self) -> pd.Series:
+        """Total demand flux (sum over all demand reactions)."""
+        return self.demand_fluxes.sum(axis=1)
+
+    def plot_supply_demand(
+        self,
+        *,
+        ax: Axes | None = None,
+        grid: bool = True,
+    ) -> FigAx:
+        """Plot total supply and demand fluxes on a single log-log axis.
+
+        Parameters
+        ----------
+        ax
+            Axis to plot on. Created if None.
+        grid
+            Whether to add a grid.
+
+        Returns
+        -------
+        FigAx
+            Figure and Axes objects.
+
+        """
+        fig, ax = _default_fig_ax(ax=ax, grid=grid)
+        ax.plot(self.total_supply.index, self.total_supply, label="supply")
+        ax.plot(self.total_demand.index, self.total_demand, label="demand")
+        ax.axvline(self.steady_state_conc, color="black", linestyle="--", alpha=0.5)
+        ax.set(xscale="log", yscale="log", xlabel="concentration", ylabel="flux")
+        ax.legend()
+        return fig, ax
+
+    def plot(
+        self,
+        *,
+        figsize: tuple[float, float] | None = (12.0, 4.0),
+        grid: bool = True,
+    ) -> FigAxs:
+        """Plot a multi-panel summary of the rate characteristics.
+
+        The figure has three log-log panels: total supply versus total demand,
+        the per-reaction supply fluxes, and the per-reaction demand fluxes. The
+        original steady-state concentration is marked on each panel.
+
+        Parameters
+        ----------
+        figsize
+            Size of the figure.
+        grid
+            Whether to add a grid to each panel.
+
+        Returns
+        -------
+        FigAxs
+            Figure and Axes objects.
+
+        """
+        fig, axs = _default_fig_axs(
+            ncols=3,
+            nrows=1,
+            figsize=figsize,
+            grid=grid,
+            sharex=True,
+            sharey=False,
+        )
+        ax_total, ax_supply, ax_demand = axs
+
+        self.plot_supply_demand(ax=ax_total, grid=grid)
+        ax_total.set_title("Supply vs demand")
+
+        for ax, fluxes, title in (
+            (ax_supply, self.supply_fluxes, "Supply reactions"),
+            (ax_demand, self.demand_fluxes, "Demand reactions"),
+        ):
+            for name in fluxes.columns:
+                ax.plot(fluxes.index, fluxes[name], label=name)
+            ax.axvline(self.steady_state_conc, color="black", linestyle="--", alpha=0.5)
+            ax.set(xscale="log", yscale="log", xlabel="concentration", ylabel="flux")
+            ax.set_title(title)
+            if len(fluxes.columns) > 0:
+                ax.legend()
+
+        return fig, axs
+
+
+def rate_characteristics(
+    model: Model,
+    variable: str,
+    *,
+    min_factor: float = 100.0,
+    max_factor: float = 100.0,
+    n_points: int = 256,
+    parallel: bool = True,
+    integrator: IntegratorType | None = None,
+) -> RateCharacteristics:
+    """Compute supply-demand rate characteristics for a variable.
+
+    The chosen variable is clamped to a logarithmically spaced range of
+    concentrations around its steady-state value. At each concentration the
+    steady state of the remaining variables is recomputed and the supply
+    (producing) and demand (consuming) reaction fluxes are collected. Plotting
+    these against the clamped concentration places the steady state in the
+    context of its full operating curve.
+
+    Reactions are classified structurally from the stoichiometry evaluated at
+    the original steady state: a positive coefficient marks a supply reaction,
+    a negative one a demand reaction.
+
+    Parameters
+    ----------
+    model
+        Metabolic model instance.
+    variable
+        Name of the variable to scan.
+    min_factor
+        Lower bound of the scan, as ``steady_state_conc / min_factor``.
+    max_factor
+        Upper bound of the scan, as ``steady_state_conc * max_factor``.
+    n_points
+        Number of concentrations to scan (log-spaced).
+    parallel
+        Whether to compute the steady states in parallel.
+    integrator
+        Integrator to use for steady-state calculation.
+
+    Returns
+    -------
+    RateCharacteristics
+        Supply and demand fluxes and the original steady-state concentration.
+
+    Raises
+    ------
+    ValueError
+        If the variable does not participate in any reaction.
+
+    Examples
+    --------
+        >>> rc = rate_characteristics(model, "ATP")
+        >>> rc.plot()
+
+    """
+    ss = (
+        Simulator(model, integrator=integrator)
+        .simulate_to_steady_state()
+        .get_result()
+        .unwrap_or_err()
+        .get_new_y0()
+    )
+    ss_conc = ss[variable]
+
+    try:
+        stoich = model.get_stoichiometries_of_variable(variable, variables=ss)
+    except KeyError:
+        stoich = {}
+    supply_rxns = [rxn for rxn, coef in stoich.items() if coef > 0]
+    demand_rxns = [rxn for rxn, coef in stoich.items() if coef < 0]
+    if not supply_rxns and not demand_rxns:
+        msg = f"Variable {variable!r} does not participate in any reaction"
+        raise ValueError(msg)
+
+    clamped = copy.deepcopy(model)
+    clamped.make_variable_static(variable)
+
+    concs = np.geomspace(ss_conc / min_factor, ss_conc * max_factor, n_points)
+    res = steady_state(
+        clamped,
+        to_scan=pd.DataFrame({variable: concs}),
+        parallel=parallel,
+        integrator=integrator,
+    )
+    fluxes = res.fluxes
+
+    return RateCharacteristics(
+        supply_fluxes=fluxes.loc[:, supply_rxns],
+        demand_fluxes=fluxes.loc[:, demand_rxns],
+        steady_state_conc=ss_conc,
     )

--- a/tests/test_mca.py
+++ b/tests/test_mca.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from matplotlib import pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
-from mxlpy import Model, fns
+from mxlpy import Model, Simulator, fns
 from mxlpy.mca import (
+    RateCharacteristics,
     SteadyStateStability,
     parameter_elasticities,
+    rate_characteristics,
     response_coefficients,
     steady_state_stability,
     variable_elasticities,
@@ -233,3 +238,106 @@ def test_steady_state_stability_spectral_abscissa_matches_eigenvalues() -> None:
     result = steady_state_stability(linear_chain(), ss)
     max_real = max(float(ev.real) for ev in result.eigenvalues)
     assert result.spectral_abscissa == pytest.approx(max_real)
+
+
+###############################################################################
+# rate_characteristics
+###############################################################################
+
+
+def test_rate_characteristics_returns_result_type() -> None:
+    result = rate_characteristics(linear_chain(), "B", n_points=16, parallel=False)
+    assert isinstance(result, RateCharacteristics)
+    assert isinstance(result.steady_state_conc, float)
+
+
+def test_rate_characteristics_supply_demand_columns() -> None:
+    """B is produced by v1 (supply) and consumed by v2 (demand)."""
+    result = rate_characteristics(linear_chain(), "B", n_points=16, parallel=False)
+    assert list(result.supply_fluxes.columns) == ["v1"]
+    assert list(result.demand_fluxes.columns) == ["v2"]
+
+
+def test_rate_characteristics_n_points() -> None:
+    result = rate_characteristics(linear_chain(), "B", n_points=32, parallel=False)
+    assert len(result.supply_fluxes) == 32
+    assert len(result.demand_fluxes) == 32
+
+
+def test_rate_characteristics_steady_state_conc() -> None:
+    """At steady state k1*A = v_in and k2*B = k1*A, so A=2, B=4."""
+    model = linear_chain()
+    ss = (
+        Simulator(model)
+        .simulate_to_steady_state()
+        .get_result()
+        .unwrap_or_err()
+        .get_new_y0()
+    )
+    result = rate_characteristics(model, "B", n_points=16, parallel=False)
+    assert result.steady_state_conc == pytest.approx(ss["B"])
+    assert result.steady_state_conc == pytest.approx(4.0, rel=1e-3)
+
+
+def test_rate_characteristics_scan_bounds() -> None:
+    """Scan spans [ss / min_factor, ss * max_factor] on a log scale."""
+    result = rate_characteristics(
+        linear_chain(),
+        "B",
+        min_factor=10.0,
+        max_factor=100.0,
+        n_points=16,
+        parallel=False,
+    )
+    concs = result.demand_fluxes.index.to_numpy()
+    ss = result.steady_state_conc
+    assert concs[0] == pytest.approx(ss / 10.0)
+    assert concs[-1] == pytest.approx(ss * 100.0)
+
+
+def test_rate_characteristics_demand_increases_with_concentration() -> None:
+    """Demand flux v2 = k2 * B is monotonically increasing in B."""
+    result = rate_characteristics(linear_chain(), "B", n_points=16, parallel=False)
+    demand = result.total_demand.to_numpy()
+    assert np.all(np.diff(demand) > 0)
+
+
+def test_rate_characteristics_totals_are_series() -> None:
+    result = rate_characteristics(linear_chain(), "B", n_points=16, parallel=False)
+    assert result.total_supply.shape == (16,)
+    assert result.total_demand.shape == (16,)
+
+
+def test_rate_characteristics_no_reaction_raises() -> None:
+    """A variable that participates in no reaction is rejected."""
+    model = (
+        Model()
+        .add_variable("x", 1.0)
+        .add_parameter("k", 1.0)
+        .add_reaction(
+            "v1",
+            fn=fns.constant,
+            args=["k"],
+            stoichiometry={},
+        )
+    )
+    with pytest.raises(ValueError, match="does not participate"):
+        rate_characteristics(model, "x", n_points=4, parallel=False)
+
+
+def test_rate_characteristics_plot_supply_demand() -> None:
+    result = rate_characteristics(linear_chain(), "B", n_points=16, parallel=False)
+    fig, ax = result.plot_supply_demand()
+    assert isinstance(fig, Figure)
+    assert isinstance(ax, Axes)
+    assert ax.get_xscale() == "log"
+    assert ax.get_yscale() == "log"
+    plt.close(fig)
+
+
+def test_rate_characteristics_plot() -> None:
+    result = rate_characteristics(linear_chain(), "B", n_points=16, parallel=False)
+    fig, axs = result.plot()
+    assert isinstance(fig, Figure)
+    assert len(axs) == 3
+    plt.close(fig)


### PR DESCRIPTION
## Summary

- Add `rate_characteristics(model, variable)` and the `RateCharacteristics` result class to `mxlpy.mca` for supply-demand rate characteristic analysis: clamp a chosen variable across a log-spaced range around its steady-state concentration, recompute the steady state of the remaining variables at each point, and collect per-reaction supply/demand fluxes. This places the steady state in the context of its full operating curve.
- `RateCharacteristics` exposes `supply_fluxes` / `demand_fluxes` (one column per reaction), `total_supply` / `total_demand` sums, `steady_state_conc`, and plots: `plot()` (three log-log panels — total supply vs demand, per-reaction supply, per-reaction demand) and `plot_supply_demand()` (combined totals on one axis).
- Builds on existing infrastructure (`scan.steady_state`, `make_variable_static`, stoichiometry dict) — no new dependencies.

## Design decisions (settled during grilling)

- **Single variable only** — no all-species `dict` form; named `variable` (not `species`) for consistency with mxlpy naming.
- **`find_regulatory` dropped** from the MVP — trivially computed on the returned DataFrames, so left to users. Elasticity / partial response-coefficient panels remain deferred to a follow-up.
- **Per-reaction flux columns**; totals derived by summing.
- **Reactions classified structurally** from the stoichiometry sign evaluated once at the original steady state (positive ⇒ supply, negative ⇒ demand). Dynamic stoichiometry is classified at that single point.
- **Edge cases:** a variable in no reaction raises `ValueError`; one-sided variables (only produced or only consumed) are allowed, leaving the empty side as a zero-column frame.

## Test plan

- `uv run pytest tests/test_mca.py` — 10 new tests cover result type, supply/demand column classification, `n_points`, steady-state concentration, log-scale scan bounds, monotonic demand, total Series shapes, the no-reaction `ValueError`, and both plot methods (30 mca tests pass total).
- `uv run pyright src/mxlpy/mca.py` — clean.

Closes #123