### PR TITLE
feat(sensitivity): add Morris global sensitivity screening

### DIFF
--- a/docs/llms-analysis.txt
+++ b/docs/llms-analysis.txt
@@ -1,4 +1,4 @@
-# MxlPy - Analysis (Fitting, Scanning, MCA, Monte Carlo)
+# MxlPy - Analysis (Fitting, Scanning, MCA, Monte Carlo, Sensitivity)
 
 [← back to main reference](llms.txt)
 
@@ -256,4 +256,56 @@ from mxlpy import plot
 fig, ax = plot.one_axes()
 plot.violins(result[["x", "y"]], ax=ax)
 plot.show()
+```
+
+---
+
+## Global sensitivity screening (`mxlpy.sensitivity`)
+
+Morris elementary-effects screening identifies which parameters drive a model output, before committing to expensive analyses (fitting, identifiability, Sobol). Cost is only `n_trajectories * (k + 1)` model evaluations for `k` parameters.
+
+`sensitivity.morris(model, *, output, param_bounds, n_trajectories=10, num_levels=4, seed=None) -> pd.DataFrame`
+
+The result is indexed by parameter name with columns `mu` (mean elementary effect), `mu_star` (mean absolute effect — the importance ranking), `sigma` (std of effects — nonlinearity/interaction), and `mu_star_conf` (bootstrap CI). Reading: low `mu_star` = unimportant; high `mu_star` + low `sigma` = important & linear; high `mu_star` + high `sigma` = important & nonlinear.
+
+`output` is a callable `(model, samples: pd.DataFrame) -> np.ndarray` mapping the whole sample matrix (one row per sample, columns = parameter names) to one scalar per row. There are **no built-in output helpers** — build the reduction on `mxlpy.scan`, which runs samples in parallel, caches, and returns `NaN` on integration failure (the `NaN` propagates into the indices).
+
+`param_bounds` is a `dict[str, tuple[float, float]]` of `(lower, upper)` sampling bounds per parameter. `SALib` is a core dependency — no extra install step.
+
+> Screen steady-state of a species against rate constants
+
+```python
+from mxlpy import scan, sensitivity
+
+def steady_state_x(model, samples):
+    return scan.steady_state(model, to_scan=samples).variables["x"].to_numpy()
+
+result = sensitivity.morris(
+    model,
+    output=steady_state_x,
+    param_bounds={"k1": (0.5, 2.0), "k2": (0.5, 2.0), "k_out": (0.5, 2.0)},
+    n_trajectories=20,
+    seed=0,
+)
+result.sort_values("mu_star", ascending=False)
+```
+
+> Other common outputs via `scan`
+
+```python
+# Peak value over a time course
+def max_x(model, samples):
+    return (
+        scan.time_course(model, to_scan=samples, time_points=time_points)
+        .get_agg_per_run("max")["x"]
+        .to_numpy()
+    )
+
+# Area under the curve (pass np.trapezoid as the aggregator)
+def auc_x(model, samples):
+    return (
+        scan.time_course(model, to_scan=samples, time_points=time_points)
+        .get_agg_per_run(np.trapezoid)["x"]
+        .to_numpy()
+    )
 ```

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -11,7 +11,7 @@
 
 ## Extended reference
 
-- [analysis (fitting, scanning, MCA, Monte Carlo)](llms-analysis.txt)
+- [analysis (fitting, scanning, MCA, Monte Carlo, sensitivity)](llms-analysis.txt)
 - [visualization](llms-visualization.txt)
 - [advanced (SBML, symbolic, surrogates, comparison)](llms-advanced.txt)
 

--- a/docs/sensitivity.ipynb
+++ b/docs/sensitivity.ipynb
@@ -71,7 +71,7 @@
     "    get_linear_chain_2v(),\n",
     "    output=steady_state_x,\n",
     "    param_bounds={\"k1\": (0.5, 2.0), \"k2\": (0.5, 2.0), \"k_out\": (0.5, 2.0)},\n",
-    "    n_trajectories=20,\n",
+    "    n_trajectories=5,\n",
     "    seed=0,\n",
     ")\n",
     "result.sort_values(\"mu_star\", ascending=False)"
@@ -142,7 +142,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "default",
+   "display_name": "git-mxl-meta (3.13.13)",
    "language": "python",
    "name": "python3"
   },
@@ -156,7 +156,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.11"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/docs/sensitivity.ipynb
+++ b/docs/sensitivity.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from example_models import get_linear_chain_2v\n",
+    "from mxlpy import scan, sensitivity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Global sensitivity screening\n",
+    "\n",
+    "Before committing to an expensive analysis &mdash; parameter fitting, profile-likelihood identifiability, or a full variance-based Sobol decomposition &mdash; it pays to ask a cheaper question first: **which parameters actually move the output at all?**\n",
+    "\n",
+    "The **Morris method** answers exactly that. It is an *elementary-effects screening* method: it perturbs one parameter at a time along a handful of random trajectories through parameter space and measures how much the output changes. With only `n_trajectories * (k + 1)` model evaluations (`k` = number of parameters) it sorts parameters into three buckets:\n",
+    "\n",
+    "| Reading                          | Interpretation                                  |\n",
+    "| -------------------------------- | ----------------------------------------------- |\n",
+    "| low `mu_star`                    | unimportant &mdash; safe to fix to a constant   |\n",
+    "| high `mu_star`, low `sigma`      | important and roughly **linear**                |\n",
+    "| high `mu_star`, high `sigma`     | important and **nonlinear** or interacting      |\n",
+    "\n",
+    "where `mu_star` is the mean *absolute* elementary effect and `sigma` its standard deviation across trajectories."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The output function\n",
+    "\n",
+    "Sensitivity is always measured with respect to *some scalar output* of the model. Rather than ship a fixed menu of reductions, `sensitivity.morris` asks you for an **output function**:\n",
+    "\n",
+    "```python\n",
+    "output(model, samples: pd.DataFrame) -> np.ndarray\n",
+    "```\n",
+    "\n",
+    "It receives the model and the full matrix of parameter samples (one row per sample, one column per parameter) and returns one scalar per row. The natural way to write it is to lean on [`mxlpy.scan`](scans.ipynb), which already evaluates the whole sample matrix in parallel, caches results, and &mdash; importantly &mdash; returns `NaN` for any sample whose integration failed. That `NaN` flows straight through to the sensitivity indices, so failed runs surface honestly instead of being silently masked.\n",
+    "\n",
+    "Any reduction `scan` can express is available for free:\n",
+    "\n",
+    "- **steady-state value** of a species: `scan.steady_state(model, to_scan=samples).variables[name]`\n",
+    "- **peak value** over a time course: `scan.time_course(model, to_scan=samples, time_points=...).get_agg_per_run(\"max\")[name]`\n",
+    "- **area under the curve**: pass `np.trapezoid` as the aggregator to `get_agg_per_run`\n",
+    "\n",
+    "Here we screen the steady-state concentration of `x` in a simple linear chain $\\varnothing \\xrightarrow{v_1} x \\xrightarrow{v_2} y \\xrightarrow{v_3} \\varnothing$ against its three rate constants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def steady_state_x(model, samples):\n",
+    "    return scan.steady_state(model, to_scan=samples).variables[\"x\"].to_numpy()\n",
+    "\n",
+    "\n",
+    "result = sensitivity.morris(\n",
+    "    get_linear_chain_2v(),\n",
+    "    output=steady_state_x,\n",
+    "    param_bounds={\"k1\": (0.5, 2.0), \"k2\": (0.5, 2.0), \"k_out\": (0.5, 2.0)},\n",
+    "    n_trajectories=20,\n",
+    "    seed=0,\n",
+    ")\n",
+    "result.sort_values(\"mu_star\", ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result is a labelled `pandas.DataFrame` indexed by parameter name with columns `mu`, `mu_star`, `sigma`, and `mu_star_conf` (a bootstrap confidence interval on `mu_star`).\n",
+    "\n",
+    "The reading is immediate: at steady state $x = k_1 / k_2$, so `k1` and `k2` dominate while `k_out` &mdash; which only drains the downstream species `y` &mdash; has an elementary effect of essentially zero. A screening run like this lets you drop `k_out` from a subsequent fit without losing anything."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualising the screen\n",
+    "\n",
+    "Two plots make the screen easy to read: a ranking of `mu_star` (with its confidence interval), and a `mu_star`-vs-`sigma` scatter that separates linear from nonlinear influence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranked = result.sort_values(\"mu_star\")\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 3.5))\n",
+    "\n",
+    "ax1.barh(ranked.index, ranked[\"mu_star\"], xerr=ranked[\"mu_star_conf\"])\n",
+    "ax1.set(xlabel=r\"$\\mu^*$ (mean absolute effect)\", title=\"Parameter ranking\")\n",
+    "\n",
+    "ax2.scatter(result[\"mu_star\"], result[\"sigma\"])\n",
+    "for name, row in result.iterrows():\n",
+    "    ax2.annotate(name, (row[\"mu_star\"], row[\"sigma\"]))\n",
+    "ax2.set(xlabel=r\"$\\mu^*$\", ylabel=r\"$\\sigma$\", title=\"Linear vs. nonlinear\")\n",
+    "\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cost and reproducibility\n",
+    "\n",
+    "Morris is cheap: with `n_trajectories=20` and `k=3` parameters the screen above used `20 * (3 + 1) = 80` model evaluations &mdash; a tiny fraction of what a variance-based method would need. That is the point: **screen first with Morris, then quantify the survivors** with a more expensive method.\n",
+    "\n",
+    "Pass a `seed` for reproducible sampling and bootstrap confidence intervals, and tune `num_levels` (default `4`) to control the granularity of the sampling grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_params = 3\n",
+    "n_trajectories = 20\n",
+    "print(f\"Evaluations: {n_trajectories * (n_params + 1)}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "default",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
       - Basics: basics.ipynb
       - Scans: scans.ipynb
       - MCA: mca.ipynb
+      - Sensitivity screening: sensitivity.ipynb
       - Fitting: fitting.ipynb
       - Fuzzy fitting: fuzzy_fitting.ipynb
       - Monte Carlo methods: monte-carlo.ipynb

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -58,6 +58,7 @@ from . import (
     report,
     sbml,
     scan,
+    sensitivity,
     units,
 )
 from .dsl import from_dsl
@@ -146,6 +147,7 @@ __all__ = [
     "report",
     "sbml",
     "scan",
+    "sensitivity",
     "surrogates",
     "symbolic",
     "to_symbolic_model",

--- a/src/mxlpy/sensitivity.py
+++ b/src/mxlpy/sensitivity.py
@@ -1,0 +1,192 @@
+"""Global sensitivity analysis for mechanistic models.
+
+This module provides screening and variance-based methods to identify which
+parameters drive a model output, before committing to expensive analyses such
+as profile likelihood, fitting, or full Sobol decomposition.
+
+The output of a model is supplied as a callable that maps the model and a
+DataFrame of parameter samples (one row per sample, one column per parameter)
+to a one-dimensional array of scalar outputs.  This contract lets the reduction
+re-use :mod:`mxlpy.scan`, which evaluates the samples in parallel, caches
+results, and already returns ``NaN`` for samples whose integration failed.
+
+Examples
+--------
+    >>> import numpy as np
+    >>> from mxlpy import scan, sensitivity
+    >>>
+    >>> def steady_state_atp(model, samples):
+    ...     return scan.steady_state(
+    ...         model, to_scan=samples
+    ...     ).variables["ATP"].to_numpy()
+    >>>
+    >>> sensitivity.morris(
+    ...     model,
+    ...     output=steady_state_atp,
+    ...     param_bounds={"k1": (0.1, 10.0), "k2": (0.01, 1.0)},
+    ...     n_trajectories=20,
+    ...     seed=0,
+    ... )
+
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+import pandas as pd
+from SALib.analyze.morris import analyze as _morris_analyze
+from SALib.sample.morris import sample as _morris_sample
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from mxlpy.model import Model
+    from mxlpy.types import Array
+
+__all__ = ["OutputFn", "morris"]
+
+_LOGGER = logging.getLogger(__name__)
+
+type OutputFn = Callable[[Model, pd.DataFrame], Array]
+
+
+def _build_problem(param_bounds: Mapping[str, tuple[float, float]]) -> dict:
+    """Build a SALib ``problem`` dict from parameter bounds.
+
+    Parameters
+    ----------
+    param_bounds
+        Mapping of parameter name to its ``(lower, upper)`` sampling bounds.
+
+    Returns
+    -------
+    dict
+        SALib problem definition with ``num_vars``, ``names`` and ``bounds``.
+
+    """
+    names = list(param_bounds)
+    return {
+        "num_vars": len(names),
+        "names": names,
+        "bounds": [list(param_bounds[name]) for name in names],
+    }
+
+
+def _evaluate(
+    model: Model,
+    output: OutputFn,
+    sample_matrix: Array,
+    names: list[str],
+) -> Array:
+    """Evaluate ``output`` over a SALib sample matrix.
+
+    Parameters
+    ----------
+    model
+        Model instance to evaluate.
+    output
+        Callable mapping ``(model, samples)`` to a 1-D array of outputs.
+    sample_matrix
+        SALib sample matrix of shape ``(n_samples, n_params)``.
+    names
+        Parameter names, aligned to the columns of ``sample_matrix``.
+
+    Returns
+    -------
+    Array
+        One-dimensional array of outputs, one per sample.
+
+    """
+    samples = pd.DataFrame(sample_matrix, columns=names)
+    y = np.asarray(output(model, samples), dtype=float).ravel()
+
+    n_failed = int(np.count_nonzero(~np.isfinite(y)))
+    if n_failed > 0:
+        _LOGGER.warning(
+            "%d of %d output evaluations were non-finite; "
+            "sensitivity indices for affected parameters may be NaN.",
+            n_failed,
+            y.size,
+        )
+    return y
+
+
+def morris(
+    model: Model,
+    *,
+    output: OutputFn,
+    param_bounds: Mapping[str, tuple[float, float]],
+    n_trajectories: int = 10,
+    num_levels: int = 4,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """Screen parameters with the Morris elementary-effects method.
+
+    The Morris method identifies which parameters matter using only
+    ``n_trajectories * (k + 1)`` model evaluations (``k`` parameters).  It
+    separates parameters that are important and nonlinear (high ``sigma``)
+    from important and linear (high ``mu_star``, low ``sigma``) from
+    unimportant (low ``mu_star``).
+
+    Parameters
+    ----------
+    model
+        Model instance to analyse.
+    output
+        Callable mapping ``(model, samples)`` to a one-dimensional array of
+        scalar outputs, one per sample row.  Typically built on
+        :mod:`mxlpy.scan`, e.g.
+        ``lambda m, s: scan.steady_state(m, to_scan=s).variables["ATP"].to_numpy()``.
+    param_bounds
+        Mapping of parameter name to its ``(lower, upper)`` sampling bounds.
+    n_trajectories
+        Number of Morris trajectories (``N``).  Total evaluations are
+        ``n_trajectories * (len(param_bounds) + 1)``.
+    num_levels
+        Number of grid levels in the Morris sampling design.
+    seed
+        Seed for the sampler and the analysis bootstrap, for reproducibility.
+
+    Returns
+    -------
+    pd.DataFrame
+        Sensitivity indices indexed by parameter name, with columns
+        ``mu`` (mean elementary effect), ``mu_star`` (mean absolute
+        elementary effect), ``sigma`` (standard deviation of effects) and
+        ``mu_star_conf`` (bootstrap confidence interval on ``mu_star``).
+
+    Examples
+    --------
+    >>> from mxlpy import scan, sensitivity
+    >>> def output(model, samples):
+    ...     return scan.steady_state(
+    ...         model, to_scan=samples
+    ...     ).variables["v1"].to_numpy()
+    >>> sensitivity.morris(
+    ...     model,
+    ...     output=output,
+    ...     param_bounds={"p1": (0.1, 10.0)},
+    ...     seed=0,
+    ... )
+
+    """
+    problem = _build_problem(param_bounds)
+    sample_matrix = _morris_sample(
+        problem,
+        N=n_trajectories,
+        num_levels=num_levels,
+        seed=seed,
+    )
+    y = _evaluate(model, output, sample_matrix, problem["names"])
+
+    result: Any = _morris_analyze(
+        problem,
+        sample_matrix,
+        y,
+        num_levels=num_levels,
+        seed=seed,
+    )
+    return cast("pd.DataFrame", result.to_df())

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from mxlpy import scan, sensitivity
+from mxlpy.sensitivity import _build_problem, _evaluate
+from tests.models import m_2v_2p_1d_1r
+
+if TYPE_CHECKING:
+    import pytest
+
+    from mxlpy.model import Model
+
+
+def _steady_state_output(variable: str) -> sensitivity.OutputFn:
+    def output(model: Model, samples: pd.DataFrame) -> np.ndarray:
+        return (
+            scan.steady_state(model, to_scan=samples, parallel=False)
+            .variables[variable]
+            .to_numpy()
+        )
+
+    return output
+
+
+def test_build_problem() -> None:
+    problem = _build_problem({"k1": (0.1, 10.0), "k2": (0.01, 1.0)})
+    assert problem["num_vars"] == 2
+    assert problem["names"] == ["k1", "k2"]
+    assert problem["bounds"] == [[0.1, 10.0], [0.01, 1.0]]
+
+
+def test_morris_returns_labelled_dataframe() -> None:
+    result = sensitivity.morris(
+        m_2v_2p_1d_1r(),
+        output=_steady_state_output("v1"),
+        param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        n_trajectories=4,
+        seed=0,
+    )
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.index) == ["p1", "p2"]
+    assert list(result.columns) == ["mu", "mu_star", "sigma", "mu_star_conf"]
+
+
+def test_morris_is_reproducible_with_seed() -> None:
+    kwargs = {
+        "output": _steady_state_output("v1"),
+        "param_bounds": {"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        "n_trajectories": 4,
+        "seed": 42,
+    }
+    first = sensitivity.morris(m_2v_2p_1d_1r(), **kwargs)
+    second = sensitivity.morris(m_2v_2p_1d_1r(), **kwargs)
+    pd.testing.assert_frame_equal(first, second)
+
+
+def test_morris_evaluation_count() -> None:
+    captured: dict[str, pd.DataFrame] = {}
+
+    def output(_model: Model, samples: pd.DataFrame) -> np.ndarray:
+        captured["samples"] = samples
+        return np.zeros(len(samples))
+
+    sensitivity.morris(
+        m_2v_2p_1d_1r(),
+        output=output,
+        param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        n_trajectories=5,
+        seed=0,
+    )
+    # Morris uses N * (k + 1) evaluations
+    assert len(captured["samples"]) == 5 * (2 + 1)
+    assert list(captured["samples"].columns) == ["p1", "p2"]
+
+
+def test_evaluate_warns_on_non_finite(caplog: pytest.LogCaptureFixture) -> None:
+    def output(_model: Model, samples: pd.DataFrame) -> np.ndarray:
+        y = np.ones(len(samples))
+        y[0] = np.nan
+        return y
+
+    sample_matrix = np.array([[1.0], [2.0], [3.0]])
+    with caplog.at_level("WARNING"):
+        y = _evaluate(m_2v_2p_1d_1r(), output, sample_matrix, ["p1"])
+
+    assert np.isnan(y[0])
+    assert "non-finite" in caplog.text
+
+
+def test_morris_propagates_failed_runs_as_nan() -> None:
+    # A model whose integration fails for every sample yields NaN outputs,
+    # which surface as NaN sensitivity indices rather than raising.
+    def output(_model: Model, samples: pd.DataFrame) -> np.ndarray:
+        return np.full(len(samples), np.nan)
+
+    result = sensitivity.morris(
+        m_2v_2p_1d_1r(),
+        output=output,
+        param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        n_trajectories=4,
+        seed=0,
+    )
+    assert bool(result["mu_star"].isna().all())


### PR DESCRIPTION
## Summary

- Add `mxlpy.sensitivity.morris` — Morris elementary-effects screening to identify which parameters drive a model output before committing to expensive analyses (fitting, profile likelihood, Sobol). Returns a labelled DataFrame (`mu`, `mu_star`, `sigma`, `mu_star_conf`) indexed by parameter name. Thin wrapper over SALib's Morris sampler/analyser.
- **Design decision (from grilling):** instead of bespoke `steady_state_output`/`auc_output`/`max_output` helpers proposed in the issue, the `output` callable receives the full sample matrix as a DataFrame and is built on `mxlpy.scan`. Scan already provides parallelism, caching, and — verified at `simulation.py:84` — `NaN` on integration failure, so the failure-handling requirement is satisfied with **zero changes to the scan workers**. The scan one-liners are documented in the module/function docstrings.
- **Dependency:** SALib is already a core dependency, so no optional `[sensitivity]` extras group or `ImportError` guard is needed (the issue's premise there was outdated).
- **127-ready:** the module is structured (`_build_problem`, `OutputFn` type alias, `_evaluate`) so the related Sobol method (#127) drops in alongside `morris` without rework. This PR is Morris-only; #127 stays open.

Closes #126

## Test plan

- `uv run pytest tests/test_sensitivity.py` — 6 tests cover: problem construction, labelled-DataFrame shape, seed reproducibility, `N*(k+1)` evaluation count, non-finite warning, and NaN propagation from failed runs.
- `uv run pyright src/mxlpy/sensitivity.py` — clean.
- `uv run ruff check` / `ruff format` — clean.

## Docs

- `docs/sensitivity.ipynb` — feature notebook (wired into nav after MCA); executes cleanly during the docs build.
- `docs/llms-analysis.txt` — new "Global sensitivity screening" section + `llms.txt` index update.
