### PR TITLE
feat(sensitivity): add Sobol variance-based global sensitivity

### DIFF
--- a/docs/llms-analysis.txt
+++ b/docs/llms-analysis.txt
@@ -260,7 +260,9 @@ plot.show()
 
 ---
 
-## Global sensitivity screening (`mxlpy.sensitivity`)
+## Global sensitivity analysis (`mxlpy.sensitivity`)
+
+### Morris screening (`sensitivity.morris`)
 
 Morris elementary-effects screening identifies which parameters drive a model output, before committing to expensive analyses (fitting, identifiability, Sobol). Cost is only `n_trajectories * (k + 1)` model evaluations for `k` parameters.
 
@@ -308,4 +310,30 @@ def auc_x(model, samples):
         .get_agg_per_run(np.trapezoid)["x"]
         .to_numpy()
     )
+```
+
+### Variance-based Sobol indices (`sensitivity.sobol`)
+
+Once Morris has screened out the unimportant parameters, Sobol quantifies *how much* of the output variance each survivor explains. Cost is `n_samples * (k + 2)` model evaluations, so it is a deliberate follow-on, not a first pass.
+
+`sensitivity.sobol(model, *, output, param_bounds, n_samples=1024, seed=None) -> pd.DataFrame`
+
+`output` and `param_bounds` use the **same contract as `morris`** (batch callable on `mxlpy.scan`; `dict[str, tuple[float, float]]` bounds). `n_samples` must be a power of two (`ValueError` otherwise). The result is indexed by parameter name with columns `S1` (first-order index — variance explained alone), `ST` (total-order index — variance explained including all interactions), and their bootstrap CIs `S1_conf`, `ST_conf`. Reading: high `S1` = direct driver; large `ST - S1` gap = the parameter acts mainly through interactions; `ST ≈ 0` = negligible.
+
+> Quantify the survivors after a Morris screen
+
+```python
+from mxlpy import scan, sensitivity
+
+def steady_state_x(model, samples):
+    return scan.steady_state(model, to_scan=samples).variables["x"].to_numpy()
+
+result = sensitivity.sobol(
+    model,
+    output=steady_state_x,
+    param_bounds={"k1": (0.5, 2.0), "k2": (0.5, 2.0)},
+    n_samples=1024,   # power of two; total evals = n_samples * (k + 2)
+    seed=0,
+)
+result.sort_values("ST", ascending=False)
 ```

--- a/docs/sensitivity.ipynb
+++ b/docs/sensitivity.ipynb
@@ -19,7 +19,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Global sensitivity screening\n",
+    "# Global sensitivity analysis\n",
     "\n",
     "Before committing to an expensive analysis &mdash; parameter fitting, profile-likelihood identifiability, or a full variance-based Sobol decomposition &mdash; it pays to ask a cheaper question first: **which parameters actually move the output at all?**\n",
     "\n",
@@ -137,6 +137,81 @@
     "n_params = 3\n",
     "n_trajectories = 20\n",
     "print(f\"Evaluations: {n_trajectories * (n_params + 1)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## From screening to quantification: Sobol indices\n",
+    "\n",
+    "Morris tells you *which* parameters matter; it does not tell you *how much* each one explains, nor cleanly separate a parameter's own effect from the effect of its interactions. The **Sobol method** does both. It is a *variance-based* method: it decomposes the total variance of the output into the share attributable to each parameter.\n",
+    "\n",
+    "It returns two indices per parameter:\n",
+    "\n",
+    "| Index | Meaning |\n",
+    "| ----- | ------- |\n",
+    "| `S1` (first-order) | fraction of output variance explained by that parameter **alone** |\n",
+    "| `ST` (total-order) | fraction explained by that parameter **including all of its interactions** |\n",
+    "\n",
+    "The gap `ST - S1` is the interaction signal: if it is large, the parameter matters mostly *through* other parameters rather than on its own.\n",
+    "\n",
+    "`sobol` takes the **same `output` and `param_bounds` contract as `morris`**, so the reduction you already wrote carries over unchanged. The one new knob is `n_samples` (the Saltelli base sample size), which **must be a power of two** &mdash; passing anything else raises a `ValueError`. The total cost is `n_samples * (k + 2)` model evaluations, which is why you screen with Morris first and reserve Sobol for the survivors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_sobol = sensitivity.sobol(\n",
+    "    get_linear_chain_2v(),\n",
+    "    output=steady_state_x,\n",
+    "    param_bounds={\"k1\": (0.5, 2.0), \"k2\": (0.5, 2.0), \"k_out\": (0.5, 2.0)},\n",
+    "    n_samples=512,\n",
+    "    seed=0,\n",
+    ")\n",
+    "result_sobol.sort_values(\"ST\", ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The result is a labelled `pandas.DataFrame` indexed by parameter name with columns `S1`, `ST`, and their bootstrap confidence intervals `S1_conf`, `ST_conf`.\n",
+    "\n",
+    "The story matches the Morris screen but is now quantitative: with $x = k_1 / k_2$ at steady state, `k1` and `k2` carry essentially all of the variance while `k_out` contributes nothing. Here `S1` and `ST` are close for every parameter, telling us the influence is largely additive over this box rather than interaction-driven."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ranked = result_sobol.sort_values(\"ST\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(6, 3.5))\n",
+    "y = np.arange(len(ranked))\n",
+    "ax.barh(\n",
+    "    y - 0.2, ranked[\"S1\"], height=0.4, xerr=ranked[\"S1_conf\"], label=\"S1 (first-order)\"\n",
+    ")\n",
+    "ax.barh(\n",
+    "    y + 0.2, ranked[\"ST\"], height=0.4, xerr=ranked[\"ST_conf\"], label=\"ST (total-order)\"\n",
+    ")\n",
+    "ax.set_yticks(y, ranked.index)\n",
+    "ax.set(xlabel=\"Sobol index\", title=\"Variance decomposition\")\n",
+    "ax.legend()\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Screen, then quantify.** Morris is the cheap first pass that discards parameters you can safely fix; Sobol is the more expensive second pass that puts numbers on the ones that survive. Used together they turn a high-dimensional parameter space into a short, ranked list of the parameters worth fitting or measuring."
    ]
   }
  ],

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ nav:
       - Basics: basics.ipynb
       - Scans: scans.ipynb
       - MCA: mca.ipynb
-      - Sensitivity screening: sensitivity.ipynb
+      - Sensitivity analysis: sensitivity.ipynb
       - Fitting: fitting.ipynb
       - Fuzzy fitting: fuzzy_fitting.ipynb
       - Monte Carlo methods: monte-carlo.ipynb

--- a/src/mxlpy/sensitivity.py
+++ b/src/mxlpy/sensitivity.py
@@ -38,7 +38,9 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 import pandas as pd
 from SALib.analyze.morris import analyze as _morris_analyze
+from SALib.analyze.sobol import analyze as _sobol_analyze
 from SALib.sample.morris import sample as _morris_sample
+from SALib.sample.sobol import sample as _sobol_sample
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -46,7 +48,7 @@ if TYPE_CHECKING:
     from mxlpy.model import Model
     from mxlpy.types import Array
 
-__all__ = ["OutputFn", "morris"]
+__all__ = ["OutputFn", "morris", "sobol"]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -190,3 +192,93 @@ def morris(
         seed=seed,
     )
     return cast("pd.DataFrame", result.to_df())
+
+
+def sobol(
+    model: Model,
+    *,
+    output: OutputFn,
+    param_bounds: Mapping[str, tuple[float, float]],
+    n_samples: int = 1024,
+    seed: int | None = None,
+) -> pd.DataFrame:
+    """Quantify parameter influence with variance-based Sobol indices.
+
+    The Sobol method decomposes the variance of a model output into the
+    contributions of each parameter.  Unlike Morris screening, which only
+    ranks parameters, Sobol quantifies *how much* of the output variance each
+    parameter explains (``S1``, first-order) and how much it explains
+    including all of its interactions (``ST``, total-order).  A large gap
+    ``ST - S1`` flags a parameter that matters mostly through interactions.
+
+    The cost is ``n_samples * (k + 2)`` model evaluations for ``k``
+    parameters, so screen with :func:`morris` first and quantify only the
+    survivors with :func:`sobol`.
+
+    Parameters
+    ----------
+    model
+        Model instance to analyse.
+    output
+        Callable mapping ``(model, samples)`` to a one-dimensional array of
+        scalar outputs, one per sample row.  Typically built on
+        :mod:`mxlpy.scan`, e.g.
+        ``lambda m, s: scan.steady_state(m, to_scan=s).variables["ATP"].to_numpy()``.
+    param_bounds
+        Mapping of parameter name to its ``(lower, upper)`` sampling bounds.
+    n_samples
+        Base sample size of the Saltelli design.  Must be a power of two.
+        Total evaluations are ``n_samples * (len(param_bounds) + 2)``.
+    seed
+        Seed for the sampler and the analysis bootstrap, for reproducibility.
+
+    Returns
+    -------
+    pd.DataFrame
+        Sensitivity indices indexed by parameter name, with columns ``S1``
+        (first-order index), ``ST`` (total-order index), ``S1_conf`` and
+        ``ST_conf`` (bootstrap confidence intervals).
+
+    Raises
+    ------
+    ValueError
+        If ``n_samples`` is not a positive power of two.
+
+    Examples
+    --------
+    >>> from mxlpy import scan, sensitivity
+    >>> def output(model, samples):
+    ...     return scan.steady_state(
+    ...         model, to_scan=samples
+    ...     ).variables["v1"].to_numpy()
+    >>> sensitivity.sobol(
+    ...     model,
+    ...     output=output,
+    ...     param_bounds={"p1": (0.1, 10.0)},
+    ...     n_samples=512,
+    ...     seed=0,
+    ... )
+
+    """
+    if n_samples <= 0 or n_samples & (n_samples - 1) != 0:
+        msg = f"n_samples must be a positive power of two, got {n_samples}."
+        raise ValueError(msg)
+
+    problem = _build_problem(param_bounds)
+    sample_matrix = _sobol_sample(
+        problem,
+        N=n_samples,
+        calc_second_order=False,
+        seed=seed,
+    )
+    y = _evaluate(model, output, sample_matrix, problem["names"])
+
+    result: Any = _sobol_analyze(
+        problem,
+        y,
+        calc_second_order=False,
+        seed=seed,
+    )
+    total_df, first_df = result.to_df()
+    merged = pd.concat([first_df, total_df], axis=1)
+    return cast("pd.DataFrame", merged[["S1", "ST", "S1_conf", "ST_conf"]])

--- a/tests/test_sensitivity.py
+++ b/tests/test_sensitivity.py
@@ -4,14 +4,13 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from mxlpy import scan, sensitivity
 from mxlpy.sensitivity import _build_problem, _evaluate
 from tests.models import m_2v_2p_1d_1r
 
 if TYPE_CHECKING:
-    import pytest
-
     from mxlpy.model import Model
 
 
@@ -105,3 +104,73 @@ def test_morris_propagates_failed_runs_as_nan() -> None:
         seed=0,
     )
     assert bool(result["mu_star"].isna().all())
+
+
+def test_sobol_returns_labelled_dataframe() -> None:
+    result = sensitivity.sobol(
+        m_2v_2p_1d_1r(),
+        output=_steady_state_output("v1"),
+        param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        n_samples=16,
+        seed=0,
+    )
+    assert isinstance(result, pd.DataFrame)
+    assert list(result.index) == ["p1", "p2"]
+    assert list(result.columns) == ["S1", "ST", "S1_conf", "ST_conf"]
+
+
+def test_sobol_is_reproducible_with_seed() -> None:
+    kwargs = {
+        "output": _steady_state_output("v1"),
+        "param_bounds": {"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        "n_samples": 16,
+        "seed": 42,
+    }
+    first = sensitivity.sobol(m_2v_2p_1d_1r(), **kwargs)
+    second = sensitivity.sobol(m_2v_2p_1d_1r(), **kwargs)
+    pd.testing.assert_frame_equal(first, second)
+
+
+def test_sobol_evaluation_count() -> None:
+    captured: dict[str, pd.DataFrame] = {}
+
+    def output(_model: Model, samples: pd.DataFrame) -> np.ndarray:
+        captured["samples"] = samples
+        return np.zeros(len(samples))
+
+    sensitivity.sobol(
+        m_2v_2p_1d_1r(),
+        output=output,
+        param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        n_samples=16,
+        seed=0,
+    )
+    # Sobol uses N * (k + 2) evaluations when second-order indices are off
+    assert len(captured["samples"]) == 16 * (2 + 2)
+    assert list(captured["samples"].columns) == ["p1", "p2"]
+
+
+@pytest.mark.parametrize("n_samples", [0, -8, 100, 1000])
+def test_sobol_rejects_non_power_of_two(n_samples: int) -> None:
+    with pytest.raises(ValueError, match="power of two"):
+        sensitivity.sobol(
+            m_2v_2p_1d_1r(),
+            output=_steady_state_output("v1"),
+            param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+            n_samples=n_samples,
+            seed=0,
+        )
+
+
+def test_sobol_propagates_failed_runs_as_nan() -> None:
+    def output(_model: Model, samples: pd.DataFrame) -> np.ndarray:
+        return np.full(len(samples), np.nan)
+
+    result = sensitivity.sobol(
+        m_2v_2p_1d_1r(),
+        output=output,
+        param_bounds={"p1": (0.1, 10.0), "p2": (0.01, 1.0)},
+        n_samples=16,
+        seed=0,
+    )
+    assert bool(result["ST"].isna().all())


### PR DESCRIPTION
## Summary

- Add `sensitivity.sobol(model, *, output, param_bounds, n_samples=1024, seed=None)`
  for variance-based global sensitivity analysis. It decomposes model output
  variance into first-order (`S1`) and total-order (`ST`) Sobol indices per
  parameter, with bootstrap confidence intervals (`S1_conf`, `ST_conf`).
- Where Morris *screens* which parameters matter, Sobol *quantifies* how much
  of the output variance each explains and flags interaction-dominated
  parameters via the `ST − S1` gap — the natural follow-on to a Morris screen.
- Extends the sensitivity notebook and `llms-analysis.txt` with a "screen, then
  quantify" Sobol section; renames the page/nav from "screening" to "analysis"
  now that it covers both methods.

## Design notes

Issue #127's proposed API repeated issue #126's *original* spec
(`output_fn(model, p)` per-sample, `n_jobs`, a `[sensitivity]` extras group,
and `steady_state_output`/`auc_output`/`max_output` helpers). None of that is
how `morris` actually shipped, so `sobol` mirrors the **shipped** module
conventions instead, for consistency:

- Same batch `output` contract — `(model, samples: pd.DataFrame) -> Array`,
  built on `mxlpy.scan` (which already parallelises, caches, and returns `NaN`
  on integration failure). No `n_jobs`, no per-sample callable.
- `param_bounds: dict[str, tuple[float, float]]` and a `seed` for
  reproducibility; reuses the existing `_build_problem` / `_evaluate` helpers.
- `SALib` stays a **core dependency** (no extras group).
- `n_samples` must be a power of two (Saltelli design) → raises `ValueError`
  with an actionable message instead of letting SALib emit a confusing warning.
- **Second-order indices (`S2`) intentionally omitted** to keep the
  common-case API simple (`calc_second_order=False`). Can be added later if
  needed. Cost is therefore `n_samples * (k + 2)` evaluations.

Returns a labelled `pd.DataFrame` indexed by parameter name with columns
`[S1, ST, S1_conf, ST_conf]`.

## Test plan

- [x] `uv run pytest tests/test_sensitivity.py` — 14 passed
- [x] `uv run ruff format` / `ruff check --fix` — clean
- [x] `uv run pyright src/mxlpy/sensitivity.py tests/test_sensitivity.py` — 0 errors
- [x] `docs/sensitivity.ipynb` executes end-to-end (`jupyter nbconvert --execute`)
- New tests cover: labelled-DataFrame shape, seed reproducibility,
  `n_samples * (k + 2)` evaluation count, power-of-two validation
  (`0, -8, 100, 1000`), and `NaN` propagation from failed runs.

Closes #127