### PR TITLE
docs(fit): document group fitting as multi-start optimization

### DIFF
--- a/docs/fitting.ipynb
+++ b/docs/fitting.ipynb
@@ -36,7 +36,7 @@
     "- `time_course`\n",
     "- `protocol_time_course`\n",
     "\n",
-    "Single model, single data, multiple initial guesses\n",
+    "Single model, single data, multiple initial guesses (a.k.a. **multi-start** optimisation)\n",
     "\n",
     "- `group_steady_state`\n",
     "- `group_time_course`\n",
@@ -322,9 +322,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Group fitting\n",
+    "## Group fitting (multi-start optimisation)\n",
     "\n",
-    "`mxlpy` supports group fitting, which is a **single-model single data** approach, where different initial conditions are fitted independently.\n"
+    "`mxlpy` supports group fitting, which is a **single-model, single-data** approach where the same model is fitted to the same data from many different initial parameter guesses.\n",
+    "\n",
+    "This is exactly what is commonly called **multi-start** (or **multistart**) optimisation: each row of the `p0` `DataFrame` is one start, the starts are run in parallel, and a `GroupFit` is returned. Use `get_best_fit()` to retrieve the best result and `get_losses()` to inspect the loss of every start.\n",
+    "\n",
+    "> A convenient way to generate diverse start guesses is `mxlpy.distributions.sample`, as shown in the *monte-carlo* combination further down."
    ]
   },
   {

--- a/docs/llms-analysis.txt
+++ b/docs/llms-analysis.txt
@@ -72,18 +72,29 @@ result = fit.steady_state(
 )
 ```
 
-> Group fitting: one model with multiple initial guesses (returns best)
+> Group fitting = multi-start (multistart) optimisation: one model, one dataset, many initial guesses run in parallel
+
+`group_*` is mxlpy's multi-start optimisation. `p0` is a `pd.DataFrame` with one
+row per start (e.g. from `mxlpy.distributions.sample`). It returns a `GroupFit`,
+not a `Result`; use `.get_best_fit()` for the best `Fit` and `.get_losses()` for
+the loss of every start. Also available: `group_time_course`,
+`group_protocol_time_course`.
 
 ```python
-p0_list = [{"k1": v, "k2": 1.0} for v in [0.1, 1.0, 5.0, 10.0]]
+import pandas as pd
+from mxlpy.distributions import LogUniform, sample
 
-result = fit.group_steady_state(
+# Space out 50 starts across the parameter ranges
+p0 = sample({"k1": LogUniform(0.01, 10.0), "k2": LogUniform(0.01, 10.0)}, n=50)
+
+group_fit = fit.group_steady_state(
     model,
-    p0=p0_list,
+    p0=p0,
     data=data,
     minimizer=LocalScipyMinimizer(),
 )
-fitted = result.unwrap_or_err()
+best = group_fit.get_best_fit()   # Fit with lowest loss
+losses = group_fit.get_losses()   # pd.Series of all start losses
 ```
 
 > Joint fitting: fit shared parameters across multiple models/datasets simultaneously

--- a/src/mxlpy/fit/__init__.py
+++ b/src/mxlpy/fit/__init__.py
@@ -6,6 +6,17 @@ Single model, single data routines
 - `time_course`
 - `protocol_time_course`
 
+Single model, single data, multiple initial guesses (multi-start)
+-----------------------------------------------------------------
+Also known as **multi-start** optimisation: the same model is fitted to the
+same data from many different initial parameter guesses (one per row of the
+`p0` DataFrame, e.g. generated with `mxlpy.distributions.sample`). The starts
+run in parallel and a `GroupFit` is returned, whose `get_best_fit()` yields
+the best result and `get_losses()` the loss of every start.
+- `group_steady_state`
+- `group_time_course`
+- `group_protocol_time_course`
+
 Multiple model, single data routines
 ------------------------------------
 - `ensemble_steady_state`


### PR DESCRIPTION
## Summary

- Issue #119 requested QMC start-guess sampling + a `fit_multistart` function. On investigation, **multi-start fitting already exists** as the `group_steady_state` / `group_time_course` / `group_protocol_time_course` family: each row of the `p0` `DataFrame` is one start, the starts run in parallel (via `mxlpy.parallel`), and a `GroupFit` is returned with `get_best_fit()` / `get_losses()`. Start guesses are already generated by `mxlpy.distributions.sample` (which returns exactly that DataFrame).
- The capability was simply **undiscoverable**: the `mxlpy.fit` package docstring omitted the `group_*` routines entirely, and nothing — notebook, docstring, or LLM docs — used the term "multi-start".
- This PR documents group fitting *as* multi-start optimization so users and LLMs searching that term find it: adds the section to the `mxlpy.fit` module docstring, labels it in `docs/fitting.ipynb`, and corrects the `docs/llms-analysis.txt` example (which wrongly passed a list of dicts and unwrapped a `Result` — the real API takes a `pd.DataFrame` and returns a `GroupFit`).

No code/behaviour change — the QMC-specific sampler from the issue was not added, since `distributions.sample` + `group_*` already cover the multi-start workflow.

## Test plan

- Docs-only change; covered by the existing docs build (notebook executes during build).
- `uv run ruff check src/mxlpy/fit/__init__.py` passes; `import mxlpy.fit` succeeds.
- Verify the rendered fitting notebook and `llms-analysis.txt` snippet reflect the real `group_*` API (`p0` DataFrame in, `GroupFit` out).

Closes #119