### PR TITLE
feat: add compose() for hierarchical model composition

### DIFF
--- a/docs/composition.ipynb
+++ b/docs/composition.ipynb
@@ -1,0 +1,162 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Model composition\n",
+    "\n",
+    "Large models are easier to build, test and maintain when assembled from smaller, independently validated **submodels** &mdash; for example a metabolic core plus a separate regulatory layer.\n",
+    "\n",
+    "`mxlpy.compose` merges two or more `Model` objects into a single new model. Components are identified **by name** across the whole namespace (variables, parameters, derived quantities, reactions, readouts, surrogates and data), and the input models are never mutated.\n",
+    "\n",
+    "```python\n",
+    "from mxlpy import compose\n",
+    "\n",
+    "full_model = compose(submodel_a, submodel_b)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from mxlpy import Model, Simulator, compose, fns, plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "disjoint-md",
+   "metadata": {},
+   "source": [
+    "## Merging disjoint submodels\n",
+    "\n",
+    "If two models share no names, `compose` simply returns a new model containing the union of all their components."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "disjoint",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def production() -> Model:\n",
+    "    return (\n",
+    "        Model()\n",
+    "        .add_parameter(\"k_in\", 1.0)\n",
+    "        .add_variable(\"x\", 1.0)\n",
+    "        .add_reaction(\"v_in\", fns.constant, args=[\"k_in\"], stoichiometry={\"x\": 1})\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "def independent() -> Model:\n",
+    "    return (\n",
+    "        Model()\n",
+    "        .add_parameter(\"k2\", 2.0)\n",
+    "        .add_variable(\"y\", 3.0)\n",
+    "        .add_reaction(\"v2\", fns.constant, args=[\"k2\"], stoichiometry={\"y\": 1})\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "merged = compose(production(), independent())\n",
+    "sorted(merged.ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conflict-md",
+   "metadata": {},
+   "source": [
+    "## Name conflicts\n",
+    "\n",
+    "By default any name defined in more than one model is treated as a conflict and raises a `ValueError`. This protects you from silently merging two unrelated components that happen to share a name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "conflict",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def consumption() -> Model:\n",
+    "    return (\n",
+    "        Model()\n",
+    "        .add_parameter(\"k_out\", 1.0)\n",
+    "        .add_variable(\"x\", 1.0)  # same name as in `production`\n",
+    "        .add_reaction(\n",
+    "            \"v_out\", fns.proportional, args=[\"k_out\", \"x\"], stoichiometry={\"x\": -1}\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    compose(production(), consumption())\n",
+    "except ValueError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "override-md",
+   "metadata": {},
+   "source": [
+    "## Sharing components on purpose\n",
+    "\n",
+    "To deliberately connect submodels through a shared component &mdash; here the species `x`, produced by one submodel and consumed by the other &mdash; pass `raise_on_conflict=False`. A warning is emitted for each overridden name and the component from the **later** model wins."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "override",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "with warnings.catch_warnings():\n",
+    "    warnings.simplefilter(\"ignore\")\n",
+    "    model = compose(production(), consumption(), raise_on_conflict=False)\n",
+    "\n",
+    "variables, _ = Simulator(model).simulate(10).get_result().unwrap_or_err()\n",
+    "\n",
+    "fig, ax = plot.lines(variables)\n",
+    "ax.set(xlabel=\"time / a.u.\", ylabel=\"concentration / a.u.\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "outro",
+   "metadata": {},
+   "source": [
+    "The composed model behaves exactly like a hand-written one: `x` relaxes towards its steady state `k_in / k_out = 1.0`.\n",
+    "\n",
+    "`compose` accepts any number of models (`compose(a, b, c, ...)`), folding them left-to-right, so you can stack several modules in a single call."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mxlpy",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -107,6 +107,24 @@ model.remove_reaction("v_out")
 model.remove_parameter("k_unused")
 ```
 
+> Compose larger models from independently-built submodels
+
+```python
+from mxlpy import compose
+
+# Merge two or more models into one new model. Components are matched by name
+# across the whole namespace; the inputs are never mutated.
+full_model = compose(metabolic_core, regulatory_layer)
+
+# Any name defined in more than one model raises ValueError by default.
+# To deliberately share a component (e.g. a species both submodels touch),
+# allow the later model to override the earlier one (emits a warning):
+full_model = compose(producer, consumer, raise_on_conflict=False)
+
+# Variadic: folds left-to-right.
+full_model = compose(a, b, c)
+```
+
 ## Available rate functions (`mxlpy.fns`)
 
 | Function | Formula | Args |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - About: index.md
   - ODE features:
       - Basics: basics.ipynb
+      - Model composition: composition.ipynb
       - Scans: scans.ipynb
       - MCA: mca.ipynb
       - Sensitivity screening: sensitivity.ipynb

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -61,6 +61,7 @@ from . import (
     sensitivity,
     units,
 )
+from .composition import compose
 from .dsl import from_dsl
 from .integrators import DefaultIntegrator, Scipy
 from .integrators.abstract import AbstractIntegrator, IntegratorProtocol
@@ -129,6 +130,7 @@ __all__ = [
     "Variable",
     "cartesian_product",
     "compare",
+    "compose",
     "configure_default_logging",
     "databases",
     "distributions",

--- a/src/mxlpy/composition.py
+++ b/src/mxlpy/composition.py
@@ -1,0 +1,125 @@
+"""Hierarchical model composition.
+
+Merge multiple :class:`~mxlpy.model.Model` instances into a single model,
+identifying shared components by name. This enables building large models from
+smaller, independently tested submodules (e.g. a metabolic core plus a
+regulatory layer) rather than as one monolithic model.
+"""
+
+from __future__ import annotations
+
+import copy
+import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mxlpy.model import Model
+
+__all__ = ["compose"]
+
+
+def _remove_by_ctx(model: Model, name: str, ctx: str) -> None:
+    """Remove *name* from *model*, dispatching on its namespace context.
+
+    Variables are removed without cascading into reaction stoichiometries, so a
+    later model can re-supply the variable while existing reactions keep
+    referencing it by name.
+    """
+    if ctx == "parameter":
+        model.remove_parameter(name)
+    elif ctx == "variable":
+        model.remove_variable(name, remove_stoichiometries=False)
+    elif ctx == "derived":
+        model.remove_derived(name)
+    elif ctx == "reaction":
+        model.remove_reaction(name)
+    elif ctx == "readout":
+        model.remove_readout(name)
+    elif ctx == "data":
+        model.remove_data(name)
+    elif ctx == "surrogate" and name in model.get_raw_surrogates(as_copy=False):
+        # Surrogate output names also live in the namespace; only whole
+        # surrogates can be removed by name (output collisions are best-effort).
+        model.remove_surrogate(name)
+
+
+def _merge_into(result: Model, model: Model, *, raise_on_conflict: bool) -> None:
+    """Fold all components of *model* into *result* in place."""
+    if duplicates := sorted(set(result.ids) & set(model.ids)):
+        if raise_on_conflict:
+            msg = (
+                f"Cannot compose models: duplicate names {duplicates}. "
+                "Rename the conflicting components in one of the models, or pass "
+                "raise_on_conflict=False to let the later model override them."
+            )
+            raise ValueError(msg)
+        for name in duplicates:
+            warnings.warn(
+                f"Component {name!r} is overridden by a later model during "
+                "composition.",
+                UserWarning,
+                stacklevel=3,
+            )
+            _remove_by_ctx(result, name, result.ids[name])
+
+    result.add_parameters(model.get_raw_parameters())
+    result.add_variables(model.get_raw_variables())
+    for name, derived in model.get_raw_derived().items():
+        result.add_derived(name, derived.fn, args=derived.args, unit=derived.unit)
+    for name, reaction in model.get_raw_reactions().items():
+        result.add_reaction(
+            name,
+            reaction.fn,
+            args=reaction.args,
+            stoichiometry=dict(reaction.stoichiometry),
+            unit=reaction.unit,
+        )
+    for name, readout in model.get_raw_readouts().items():
+        result.add_readout(name, readout.fn, args=readout.args, unit=readout.unit)
+    for name, surrogate in model.get_raw_surrogates().items():
+        result.add_surrogate(name, copy.deepcopy(surrogate))
+    for name, data in model._data.items():  # noqa: SLF001
+        result.add_data(name, copy.deepcopy(data))
+
+
+def compose(*models: Model, raise_on_conflict: bool = True) -> Model:
+    """Merge multiple models into a single new model.
+
+    Components are identified by name across the global namespace (variables,
+    parameters, derived quantities, reactions, readouts, surrogates and data).
+    Models are folded left-to-right into a copy of the first model; the inputs
+    are never mutated.
+
+    Examples
+    --------
+        >>> full_model = compose(signalling, metabolic)
+
+    Parameters
+    ----------
+    models
+        Two or more models to merge. A single model returns a copy.
+    raise_on_conflict
+        If ``True`` (default), any name defined in more than one model raises a
+        ``ValueError``. If ``False``, a warning is emitted and the component
+        from the later model overrides the earlier one.
+
+    Returns
+    -------
+    Model
+        A new model containing the union of all components.
+
+    Raises
+    ------
+    ValueError
+        If no models are given, or if names collide and
+        ``raise_on_conflict`` is ``True``.
+
+    """
+    if not models:
+        msg = "compose() requires at least one model"
+        raise ValueError(msg)
+
+    result = copy.deepcopy(models[0])
+    for model in models[1:]:
+        _merge_into(result, model, raise_on_conflict=raise_on_conflict)
+    return result

--- a/tests/test_composition.py
+++ b/tests/test_composition.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from mxlpy import Model, Simulator, compose, fns
+
+
+def _producer() -> Model:
+    """Model that produces x."""
+    return (
+        Model()
+        .add_parameter("k_in", 1.0)
+        .add_variable("x", 1.0)
+        .add_reaction("v_in", fns.constant, args=["k_in"], stoichiometry={"x": 1})
+    )
+
+
+def _consumer() -> Model:
+    """Model that consumes the shared variable x."""
+    return (
+        Model()
+        .add_parameter("k_out", 1.0)
+        .add_variable("x", 1.0)
+        .add_reaction(
+            "v_out", fns.proportional, args=["k_out", "x"], stoichiometry={"x": -1}
+        )
+    )
+
+
+def _independent() -> Model:
+    """Model with a disjoint namespace from _producer."""
+    return (
+        Model()
+        .add_parameter("k2", 2.0)
+        .add_variable("y", 3.0)
+        .add_reaction("v2", fns.constant, args=["k2"], stoichiometry={"y": 1})
+    )
+
+
+def test_compose_disjoint_merges_all_components() -> None:
+    merged = compose(_producer(), _independent())
+
+    assert set(merged.get_variable_names()) == {"x", "y"}
+    assert set(merged.get_parameter_names()) == {"k_in", "k2"}
+    assert set(merged.get_reaction_names()) == {"v_in", "v2"}
+
+
+def test_compose_single_model_returns_independent_copy() -> None:
+    original = _producer()
+    merged = compose(original)
+
+    assert merged is not original
+    assert merged.ids == original.ids
+    # Mutating the copy must not touch the original
+    merged.update_parameter("k_in", 99.0)
+    assert original.get_raw_parameters()["k_in"].value == 1.0
+
+
+def test_compose_no_models_raises() -> None:
+    with pytest.raises(ValueError, match="at least one model"):
+        compose()
+
+
+def test_compose_conflict_raises_by_default() -> None:
+    with pytest.raises(ValueError, match="duplicate names"):
+        compose(_producer(), _consumer())
+
+
+def test_compose_override_warns_and_later_model_wins() -> None:
+    m1 = Model().add_parameter("k", 1.0).add_variable("x", 1.0)
+    m2 = Model().add_parameter("k", 2.0).add_variable("x", 5.0)
+
+    with pytest.warns(UserWarning, match="overridden"):
+        merged = compose(m1, m2, raise_on_conflict=False)
+
+    assert merged.get_raw_parameters()["k"].value == 2.0
+    assert merged.get_raw_variables()["x"].initial_value == 5.0
+
+
+def test_compose_does_not_mutate_inputs() -> None:
+    m1 = _producer()
+    m2 = _independent()
+    ids_before_1 = m1.ids
+    ids_before_2 = m2.ids
+
+    compose(m1, m2)
+
+    assert m1.ids == ids_before_1
+    assert m2.ids == ids_before_2
+
+
+def test_compose_three_models() -> None:
+    m1 = Model().add_variable("x", 1.0)
+    m2 = Model().add_variable("y", 2.0)
+    m3 = Model().add_variable("z", 3.0)
+
+    merged = compose(m1, m2, m3)
+
+    assert set(merged.get_variable_names()) == {"x", "y", "z"}
+
+
+def test_compose_merges_derived_readouts_and_data() -> None:
+    base = Model().add_parameter("k_in", 1.0).add_variable("x", 1.0)
+    extra = (
+        Model()
+        .add_parameter("k2", 2.0)
+        .add_derived("d1", fns.proportional, args=["k2", "k2"])
+        .add_readout("r1", fns.constant, args=["k2"])
+        .add_data("dataset", pd.Series({"a": 1.0}))
+    )
+
+    merged = compose(base, extra)
+
+    assert "d1" in merged.get_raw_derived()
+    assert "r1" in merged.get_raw_readouts()
+    assert "dataset" in merged.ids
+
+
+def test_compose_shared_variable_simulates() -> None:
+    # Producer and consumer share variable x; override resolves the collision.
+    with pytest.warns(UserWarning, match="overridden"):
+        merged = compose(_producer(), _consumer(), raise_on_conflict=False)
+
+    result = Simulator(merged).simulate(10).get_result().unwrap_or_err()
+    variables = result.variables
+
+    assert "x" in variables.columns
+    # x relaxes towards the steady state k_in / k_out = 1.0
+    assert np.isclose(variables["x"].iloc[-1], 1.0, atol=1e-3)


### PR DESCRIPTION
Add `mxlpy.compose(*models, raise_on_conflict=True)` to merge two or more Model objects into a single new model, enabling large models to be assembled from smaller, independently-tested submodels (e.g. a metabolic core plus a regulatory layer). Components are identified by name across the whole namespace and the input models are never mutated.

By default any name defined in more than one model raises a ValueError, guarding against accidental merges of unrelated components that happen to share a name. Passing raise_on_conflict=False instead emits a warning and lets the later model override the earlier one, which is how submodels are deliberately wired together through a shared species. The issue's proposed `extend` alias and `shared_species` argument were dropped: `extend` added nothing over `compose`, and name-based matching plus the conflict flag cover the sharing use case.

Closes #122

