### PR TITLE
feat: native JSON model serialization (save/load)

### DIFF
--- a/docs/llms-advanced.txt
+++ b/docs/llms-advanced.txt
@@ -16,6 +16,34 @@ sbml.write(model, "path/to/output.xml")
 
 ---
 
+## Native JSON format (`mxlpy.save` / `mxlpy.load`)
+
+Version-controllable `.mxl.json` format that captures the full model structure
+(variables, parameters, reactions, derived quantities, readouts). Rate
+expressions are stored as trees of math nodes from the node set shared with
+MxlWeb, so the same files can be consumed by both tools.
+
+```python
+import mxlpy
+
+# Save a model to the native JSON format
+mxlpy.save(model, "model.mxl.json")
+
+# Load it back - all constructs restored, simulates identically
+model = mxlpy.load("model.mxl.json")
+```
+
+- Rate functions go through SymPy, so a loaded model uses generated (not the
+  original named) functions and is behaviourally identical. `save -> load ->
+  save` reaches a stable fixed point.
+- Optional metadata: `mxlpy.save(model, path, model_id="glycolysis", description="...")`.
+- Raises `mxlpy.types.SerializationError` for surrogates or rate functions that
+  cannot be parsed into an expression.
+- Each file references a `$schema` (the shared `mxl-schemas` repo) for editor
+  validation and autocompletion. Use SBML instead for cross-tool interchange.
+
+---
+
 ## Model comparison (`mxlpy.compare`)
 
 Compare simulations of two models side-by-side (e.g. before/after refactoring, or two hypotheses):

--- a/docs/serialization.ipynb
+++ b/docs/serialization.ipynb
@@ -1,0 +1,134 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "47e89460",
+   "metadata": {},
+   "source": [
+    "# Native JSON serialization\n",
+    "\n",
+    "MxlPy can read and write models in a native, version-controllable JSON format\n",
+    "(`.mxl.json`). Unlike SBML, which is the standard for cross-tool interchange,\n",
+    "the native format captures the full MxlPy model structure - variables,\n",
+    "parameters, reactions, derived quantities and readouts - and is designed to\n",
+    "produce clean, meaningful diffs in version control.\n",
+    "\n",
+    "Rate expressions are stored as **trees of math nodes** using the node set\n",
+    "shared with [MxlWeb](https://github.com/Computational-Biology-Aachen/mxl-web),\n",
+    "so the same files can be consumed by both tools."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "962c7e16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from tempfile import TemporaryDirectory\n",
+    "\n",
+    "import mxlpy\n",
+    "from mxlpy import Model, fns\n",
+    "\n",
+    "\n",
+    "def glycolysis() -> Model:\n",
+    "    return (\n",
+    "        Model()\n",
+    "        .add_variables({\"A\": 1.0, \"B\": 0.0})\n",
+    "        .add_parameters({\"k1\": 0.1, \"k2\": 0.05})\n",
+    "        .add_reaction(\n",
+    "            \"r1\",\n",
+    "            fns.mass_action_1s,\n",
+    "            args=[\"A\", \"k1\"],\n",
+    "            stoichiometry={\"A\": -1, \"B\": 1},\n",
+    "        )\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "model = glycolysis()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1b0591e",
+   "metadata": {},
+   "source": [
+    "## Saving and loading\n",
+    "\n",
+    "`mxlpy.save` writes the model, `mxlpy.load` reconstructs it. A loaded model is\n",
+    "behaviourally identical to the original and simulates to the same result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d00739c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with TemporaryDirectory() as tmp:\n",
+    "    path = Path(tmp) / \"glycolysis.mxl.json\"\n",
+    "    mxlpy.save(model, path, model_id=\"glycolysis\", description=\"Minimal example\")\n",
+    "    print(path.read_text())\n",
+    "    restored = mxlpy.load(path)\n",
+    "\n",
+    "restored"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab622b4c",
+   "metadata": {},
+   "source": [
+    "## Lossless round-trip\n",
+    "\n",
+    "The format round-trips through SymPy, so the loaded model uses generated\n",
+    "rate functions (not the original named ones) but produces identical dynamics.\n",
+    "`save -> load -> save` also reaches a stable fixed point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7490a4d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original = mxlpy.Simulator(model).simulate(50).get_result().unwrap_or_err()\n",
+    "loaded = mxlpy.Simulator(restored).simulate(50).get_result().unwrap_or_err()\n",
+    "\n",
+    "(original.get_combined() - loaded.get_combined()).abs().max()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85eb1a73",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- The file references a `$schema` from the shared\n",
+    "  [`mxl-schemas`](https://github.com/Computational-Biology-Aachen/mxl-schemas)\n",
+    "  repository, giving editor validation and autocompletion for `.mxl.json` files.\n",
+    "- Surrogates and rate functions that cannot be parsed into an expression raise\n",
+    "  `mxlpy.types.SerializationError`. Use SBML (`mxlpy.sbml`) for those, or for\n",
+    "  cross-tool interchange.\n",
+    "- The `spec_version` field tracks the format version; it is shared with MxlWeb\n",
+    "  and decoupled from the MxlPy package version."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - Neural Posterior Estimation: mxl-npe.ipynb
       - Reaction carousel: carousel.ipynb
   - Metaprogramming: metaprogramming.ipynb
+  - Serialization: serialization.ipynb
   - Examples: examples.ipynb
   - Reporting: report.ipynb
   - Tips:

--- a/src/mxlpy/__init__.py
+++ b/src/mxlpy/__init__.py
@@ -70,6 +70,7 @@ from .mc import Cache
 from .minimizers.abstract import AbstractMinimizer, MinimizerProtocol
 from .model import Model
 from .npe.abstract import AbstractEstimator, EstimatorProtocol
+from .serialize import load, save
 from .simulation import Simulation
 from .simulator import Simulator
 from .surrogates.abstract import AbstractSurrogate, SurrogateProtocol
@@ -138,6 +139,7 @@ __all__ = [
     "fns",
     "from_dsl",
     "fuzzy",
+    "load",
     "make_protocol",
     "mc",
     "mca",
@@ -145,6 +147,7 @@ __all__ = [
     "npe",
     "plot",
     "report",
+    "save",
     "sbml",
     "scan",
     "sensitivity",

--- a/src/mxlpy/meta/_mathml/__init__.py
+++ b/src/mxlpy/meta/_mathml/__init__.py
@@ -1,6 +1,21 @@
 from __future__ import annotations
 
-from .base import Base, Binary, Name, Nary, Nullary, Num, Unary
+from dataclasses import fields
+from typing import Any
+
+from .base import (
+    _FIELD_TO_KEY,
+    Base,
+    Binary,
+    Bool,
+    E,
+    Name,
+    Nary,
+    Nullary,
+    Num,
+    Pi,
+    Unary,
+)
 from .binary import Implies, Pow
 from .nary import (
     Add,
@@ -76,6 +91,7 @@ __all__ = [
     "Atan",
     "Base",
     "Binary",
+    "Bool",
     "Ceiling",
     "Cos",
     "Cosh",
@@ -84,6 +100,7 @@ __all__ = [
     "Csc",
     "Csch",
     "Divide",
+    "E",
     "Eq",
     "Exp",
     "Factorial",
@@ -107,6 +124,7 @@ __all__ = [
     "Nullary",
     "Num",
     "Or",
+    "Pi",
     "Piecewise",
     "Pow",
     "RateOf",
@@ -120,4 +138,56 @@ __all__ = [
     "Tanh",
     "Unary",
     "Xor",
+    "node_from_dict",
 ]
+
+# Abstract intermediates that must never be instantiated from a dict.
+_ABSTRACT_NODES = {"Base", "Nullary", "Unary", "Binary", "Nary"}
+_NODE_REGISTRY: dict[str, type[Base]] = {}
+
+
+def _build_registry() -> dict[str, type[Base]]:
+    registry: dict[str, type[Base]] = {}
+    stack = list(Base.__subclasses__())
+    while stack:
+        cls = stack.pop()
+        stack.extend(cls.__subclasses__())
+        if cls.__name__ not in _ABSTRACT_NODES:
+            registry[cls.__name__] = cls
+    return registry
+
+
+def node_from_dict(data: dict[str, Any]) -> Base:
+    """Reconstruct an expression node tree from its arity-accurate dict form.
+
+    Parameters
+    ----------
+    data
+        Mapping with a ``"type"`` discriminator and the node's operands, as
+        produced by :meth:`Base.to_dict`.
+
+    Returns
+    -------
+    Base
+        The reconstructed expression node.
+
+    """
+    if not _NODE_REGISTRY:
+        _NODE_REGISTRY.update(_build_registry())
+
+    node_type = data["type"]
+    if (cls := _NODE_REGISTRY.get(node_type)) is None:
+        msg = f"Unknown expression node type {node_type!r}"
+        raise ValueError(msg)
+
+    kwargs: dict[str, Any] = {}
+    for f in fields(cls):  # type: ignore[arg-type]
+        key = _FIELD_TO_KEY.get(f.name, f.name)
+        raw = data[key]
+        if isinstance(raw, dict) and "type" in raw:
+            kwargs[f.name] = node_from_dict(raw)
+        elif isinstance(raw, list):
+            kwargs[f.name] = [node_from_dict(c) for c in raw]
+        else:
+            kwargs[f.name] = raw
+    return cls(**kwargs)

--- a/src/mxlpy/meta/_mathml/base.py
+++ b/src/mxlpy/meta/_mathml/base.py
@@ -1,13 +1,43 @@
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+from typing import Any
 
-__all__ = ["Base", "Binary", "Name", "Nary", "Nullary", "Num", "Unary"]
+__all__ = [
+    "Base",
+    "Binary",
+    "Bool",
+    "E",
+    "Name",
+    "Nary",
+    "Nullary",
+    "Num",
+    "Pi",
+    "Unary",
+]
+
+# Dataclass field name -> JSON key. ``Name`` stores its symbol in ``name`` but
+# the shared mxlpy/mxlweb format spells leaf payloads ``value``.
+_FIELD_TO_KEY = {"name": "value"}
 
 
 @dataclass(slots=True)
 class Base(ABC):
     @abstractmethod
     def to_mxlweb(self) -> str: ...
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise this node into a JSON-compatible, arity-accurate dict."""
+        out: dict[str, Any] = {"type": type(self).__name__}
+        for f in fields(self):  # type: ignore[arg-type]
+            key = _FIELD_TO_KEY.get(f.name, f.name)
+            value = getattr(self, f.name)
+            if isinstance(value, Base):
+                out[key] = value.to_dict()
+            elif isinstance(value, list):
+                out[key] = [c.to_dict() for c in value]
+            else:
+                out[key] = value
+        return out
 
 
 @dataclass(slots=True)
@@ -47,3 +77,23 @@ class Num(Nullary):
 
     def to_mxlweb(self) -> str:
         return f"new Num({self.value})"
+
+
+@dataclass(slots=True)
+class Pi(Nullary):
+    def to_mxlweb(self) -> str:
+        return "new Pi()"
+
+
+@dataclass(slots=True)
+class E(Nullary):
+    def to_mxlweb(self) -> str:
+        return "new E()"
+
+
+@dataclass(slots=True)
+class Bool(Nullary):
+    value: bool
+
+    def to_mxlweb(self) -> str:
+        return f"new Bool({str(self.value).lower()})"

--- a/src/mxlpy/meta/sympy_tools.py
+++ b/src/mxlpy/meta/sympy_tools.py
@@ -2,18 +2,20 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import sympy
 
+from mxlpy.meta import _mathml as mml
 from mxlpy.meta.source_tools import fn_to_sympy_expr
 from mxlpy.types import Derived
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
+    from collections.abc import Callable, Iterable, Mapping
 
 __all__ = [
     "list_of_symbols",
+    "mathml_to_sympy",
     "stoichiometries_to_sympy",
     "sympy_to_inline_c",
     "sympy_to_inline_cxx",
@@ -23,6 +25,7 @@ __all__ = [
     "sympy_to_inline_mxlweb",
     "sympy_to_inline_py",
     "sympy_to_inline_rust",
+    "sympy_to_mathml",
     "sympy_to_python_fn",
 ]
 
@@ -440,3 +443,239 @@ def sympy_to_inline_mxlweb(
 
     msg = f"Cannot convert sympy type {type(expr).__name__} ({expr!r}) to MxlWeb AST"
     raise ValueError(msg)
+
+
+###############################################################################
+# sympy <-> MathML node tree
+###############################################################################
+
+# sympy function type -> MathML unary node class
+_UNARY_NODE_MAP: dict[type, Callable[[mml.Base], mml.Base]] = {
+    sympy_type: getattr(mml, name) for sympy_type, name in _UNARY_FN_MAP
+}
+# MathML unary node class name -> sympy callable
+_NODE_TO_UNARY_SYMPY: dict[str, Callable[..., sympy.Expr]] = {
+    name: sympy_type for sympy_type, name in _UNARY_FN_MAP
+}
+# sympy relational/logical type -> MathML n-ary node class
+_RELATIONAL_NODE_MAP: dict[type, Callable[[list[mml.Base]], mml.Base]] = {
+    sympy_type: getattr(mml, name) for sympy_type, name in _RELATIONAL_MAP
+}
+_NODE_TO_RELATIONAL_SYMPY: dict[str, Callable[..., sympy.Expr]] = {
+    name: sympy_type for sympy_type, name in _RELATIONAL_MAP
+}
+
+
+def sympy_to_mathml(expr: sympy.Expr) -> mml.Base:
+    """Convert a sympy expression into a MathML node tree.
+
+    The resulting tree uses the shared mxlpy/mxlweb node set
+    (:mod:`mxlpy.meta._mathml`) and is the in-memory form behind the native
+    JSON model format.
+
+    Parameters
+    ----------
+    expr
+        Sympy expression to convert
+
+    Returns
+    -------
+    mml.Base
+        Equivalent MathML expression node
+
+    """
+    # Constants (checked before Number; pi/E are not sympy.Number instances)
+    if expr is sympy.true:
+        return mml.Bool(value=True)
+    if expr is sympy.false:
+        return mml.Bool(value=False)
+    if expr is sympy.pi:
+        return mml.Pi()
+    if expr is sympy.E:
+        return mml.E()
+
+    # Numbers
+    if isinstance(expr, sympy.Number):
+        return mml.Num(value=float(expr))
+
+    # Named symbol
+    if isinstance(expr, sympy.Symbol):
+        return mml.Name(name=expr.name)
+
+    # Addition
+    if isinstance(expr, sympy.Add):
+        return mml.Add([sympy_to_mathml(cast(sympy.Expr, a)) for a in expr.args])
+
+    # Multiplication - handle negation and division
+    if isinstance(expr, sympy.Mul):
+        return _mul_to_mathml(expr)
+
+    # Powers
+    if isinstance(expr, sympy.Pow):
+        base = cast(sympy.Expr, expr.args[0])
+        exp = cast(sympy.Expr, expr.args[1])
+        if exp == sympy.Rational(1, 2):
+            return mml.Sqrt(child=sympy_to_mathml(base), base=mml.Num(value=2.0))
+        if exp == sympy.Integer(-1):
+            return mml.Divide([mml.Num(value=1.0), sympy_to_mathml(base)])
+        return mml.Pow(left=sympy_to_mathml(base), right=sympy_to_mathml(exp))
+
+    # Unary functions
+    for sympy_type, node_cls in _UNARY_NODE_MAP.items():
+        if isinstance(expr, sympy_type):
+            child = sympy_to_mathml(cast(sympy.Expr, expr.args[0]))
+            return node_cls(child)
+
+    # N-ary min/max
+    if isinstance(expr, sympy.Max):
+        return mml.Max([sympy_to_mathml(cast(sympy.Expr, a)) for a in expr.args])
+    if isinstance(expr, sympy.Min):
+        return mml.Min([sympy_to_mathml(cast(sympy.Expr, a)) for a in expr.args])
+
+    # Piecewise: sympy args are ((val, cond), ...) pairs. A trailing cond=True
+    # becomes the value-only "otherwise" branch.
+    if isinstance(expr, sympy.Piecewise):
+        children: list[mml.Base] = []
+        for pair in expr.args:
+            val = cast(sympy.Expr, pair.args[0])
+            cond = cast(sympy.Expr, pair.args[1])
+            children.append(sympy_to_mathml(val))
+            if cond is not sympy.true:
+                children.append(sympy_to_mathml(cond))
+        return mml.Piecewise(children)
+
+    # Relational and logical operators
+    for sympy_type, node_cls in _RELATIONAL_NODE_MAP.items():
+        if isinstance(expr, sympy_type):
+            return node_cls([sympy_to_mathml(cast(sympy.Expr, a)) for a in expr.args])
+
+    msg = f"Cannot convert sympy type {type(expr).__name__} ({expr!r}) to MathML node"
+    raise ValueError(msg)
+
+
+def _mul_to_mathml(expr: sympy.Mul) -> mml.Base:
+    coeff, rest_factors = expr.as_coeff_mul()
+
+    numer: list[sympy.Expr] = []
+    denom: list[sympy.Expr] = []
+    for arg in rest_factors:
+        if isinstance(arg, sympy.Pow):
+            arg_exp = cast(sympy.Expr, arg.exp)
+            if isinstance(arg_exp, sympy.Number) and arg_exp.is_negative:
+                neg_exp = cast(sympy.Expr, -arg_exp)
+                base = cast(sympy.Expr, arg.base)
+                denom.append(
+                    base if neg_exp == sympy.Integer(1) else sympy.Pow(base, neg_exp)
+                )
+                continue
+        numer.append(cast(sympy.Expr, arg))
+
+    abs_coeff = cast(sympy.Expr, -coeff if coeff.is_negative else coeff)
+    if abs_coeff != sympy.Integer(1):
+        numer = [cast(sympy.Expr, sympy.Number(abs_coeff)), *numer]
+
+    if denom:
+        n_expr: sympy.Expr = (
+            sympy.Mul(*numer)
+            if len(numer) > 1
+            else (numer[0] if numer else sympy.Integer(1))
+        )
+        d_expr: sympy.Expr = sympy.Mul(*denom) if len(denom) > 1 else denom[0]
+        inner: mml.Base = mml.Divide([sympy_to_mathml(n_expr), sympy_to_mathml(d_expr)])
+    elif len(numer) == 1:
+        inner = sympy_to_mathml(numer[0])
+    else:
+        inner = mml.Mul([sympy_to_mathml(f) for f in numer])
+
+    if coeff.is_negative:
+        return mml.Minus([inner])
+    return inner
+
+
+def mathml_to_sympy(node: mml.Base) -> sympy.Expr:
+    """Convert a MathML node tree back into a sympy expression.
+
+    Parameters
+    ----------
+    node
+        MathML expression node, e.g. produced by :func:`sympy_to_mathml` or
+        :func:`mxlpy.meta._mathml.node_from_dict`.
+
+    Returns
+    -------
+    sympy.Expr
+        Equivalent sympy expression
+
+    """
+    if isinstance(node, mml.Num):
+        value = node.value
+        if float(value).is_integer():
+            return sympy.Integer(int(value))
+        return sympy.Float(value)
+    if isinstance(node, mml.Name):
+        return sympy.Symbol(node.name)
+    if isinstance(node, mml.Pi):
+        return cast(sympy.Expr, sympy.pi)
+    if isinstance(node, mml.E):
+        return cast(sympy.Expr, sympy.E)
+    if isinstance(node, mml.Bool):
+        return cast(sympy.Expr, sympy.true if node.value else sympy.false)
+
+    if isinstance(node, mml.Add):
+        return sympy.Add(*(mathml_to_sympy(c) for c in node.children))
+    if isinstance(node, mml.Mul):
+        return sympy.Mul(*(mathml_to_sympy(c) for c in node.children))
+    if isinstance(node, mml.Minus):
+        children = [mathml_to_sympy(c) for c in node.children]
+        if len(children) == 1:
+            return cast(sympy.Expr, sympy.Mul(sympy.Integer(-1), children[0]))
+        rest = sympy.Mul(sympy.Integer(-1), sympy.Add(*children[1:]))
+        return cast(sympy.Expr, sympy.Add(children[0], rest))
+    if isinstance(node, mml.Divide):
+        children = [mathml_to_sympy(c) for c in node.children]
+        denom = sympy.Pow(sympy.Mul(*children[1:]), sympy.Integer(-1))
+        return cast(sympy.Expr, sympy.Mul(children[0], denom))
+    if isinstance(node, mml.Pow):
+        return sympy.Pow(mathml_to_sympy(node.left), mathml_to_sympy(node.right))
+    if isinstance(node, mml.Sqrt):
+        inv_base = sympy.Pow(mathml_to_sympy(node.base), sympy.Integer(-1))
+        return sympy.Pow(mathml_to_sympy(node.child), inv_base)
+    if isinstance(node, mml.Log):
+        inv_log_base = sympy.Pow(
+            sympy.log(mathml_to_sympy(node.base)), sympy.Integer(-1)
+        )
+        return cast(
+            sympy.Expr,
+            sympy.Mul(sympy.log(mathml_to_sympy(node.child)), inv_log_base),
+        )
+    if isinstance(node, mml.Max):
+        return cast(sympy.Expr, sympy.Max(*(mathml_to_sympy(c) for c in node.children)))
+    if isinstance(node, mml.Min):
+        return cast(sympy.Expr, sympy.Min(*(mathml_to_sympy(c) for c in node.children)))
+    if isinstance(node, mml.Piecewise):
+        return _piecewise_to_sympy(node)
+
+    name = type(node).__name__
+    node_any = cast(Any, node)
+    if (unary_fn := _NODE_TO_UNARY_SYMPY.get(name)) is not None:
+        return cast(sympy.Expr, unary_fn(mathml_to_sympy(node_any.child)))
+    if (rel_fn := _NODE_TO_RELATIONAL_SYMPY.get(name)) is not None:
+        return cast(
+            sympy.Expr,
+            rel_fn(*(mathml_to_sympy(c) for c in node_any.children)),
+        )
+
+    msg = f"Cannot convert MathML node {name!r} to sympy"
+    raise ValueError(msg)
+
+
+def _piecewise_to_sympy(node: mml.Piecewise) -> sympy.Expr:
+    children = node.children
+    pairs: list[tuple[sympy.Expr, sympy.Expr]] = []
+    i = 0
+    while i + 1 < len(children):
+        pairs.append((mathml_to_sympy(children[i]), mathml_to_sympy(children[i + 1])))
+        i += 2
+    if i < len(children):  # trailing "otherwise" value
+        pairs.append((mathml_to_sympy(children[i]), cast(sympy.Expr, sympy.true)))
+    return cast(sympy.Expr, sympy.Piecewise(*pairs))

--- a/src/mxlpy/serialize.py
+++ b/src/mxlpy/serialize.py
@@ -1,0 +1,326 @@
+"""Native JSON serialisation for MxlPy models.
+
+This module reads and writes the ``.mxl.json`` format: a MxlPy-native, version
+controllable representation that captures the full model structure (variables,
+parameters, reactions, derived quantities and readouts).
+
+Rate expressions are stored as trees of math nodes using the node set shared
+with MxlWeb (:mod:`mxlpy.meta._mathml`), so the same files can be consumed by
+both tools. Models round-trip through sympy, which means a loaded model is
+behaviourally identical to the original and ``save -> load -> save`` reaches a
+stable fixed point.
+
+Examples
+--------
+>>> import mxlpy
+>>> mxlpy.save(model, "my_model.mxl.json")
+>>> model = mxlpy.load("my_model.mxl.json")
+
+"""
+
+from __future__ import annotations
+
+import json
+import linecache
+import math
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import scipy.special  # bound as `scipy`, used by generated rate fns
+
+from mxlpy.meta import _mathml as mml
+from mxlpy.meta.source_tools import fn_to_sympy_expr
+from mxlpy.meta.sympy_tools import (
+    list_of_symbols,
+    mathml_to_sympy,
+    sympy_to_mathml,
+    sympy_to_python_fn,
+)
+from mxlpy.model import Model
+from mxlpy.types import Derived, InitialAssignment, SerializationError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    import sympy
+
+    from mxlpy.types import RateFn
+
+__all__ = [
+    "SCHEMA_URL",
+    "SPEC_VERSION",
+    "load",
+    "model_from_dict",
+    "model_to_dict",
+    "save",
+]
+
+SPEC_VERSION = "1.0"
+# The schema is maintained in the shared, language-agnostic `mxl-schemas` repo
+# so it can be consumed by both mxlpy and mxlweb. It is intentionally not
+# vendored into this package. The URL is pinned to the major spec version, so a
+# file's $schema always matches the spec_version it was written with.
+_SCHEMA_MAJOR = SPEC_VERSION.split(".", 1)[0]
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/Computational-Biology-Aachen/"
+    f"mxl-schemas/main/v{_SCHEMA_MAJOR}/mxl-model.schema.json"
+)
+
+_FN_NAME = "_mxl_fn"
+
+
+###############################################################################
+# Save
+###############################################################################
+
+
+def _fn_to_node_dict(
+    fn: RateFn,
+    *,
+    origin: str,
+    args: list[str],
+) -> dict[str, Any]:
+    expr = fn_to_sympy_expr(fn, origin=origin, model_args=list_of_symbols(args))
+    if expr is None:
+        msg = f"could not convert function of {origin!r} to an expression"
+        raise SerializationError(msg)
+    return sympy_to_mathml(expr).to_dict()
+
+
+def _value_to_node_dict(
+    value: float | InitialAssignment,
+    *,
+    origin: str,
+) -> dict[str, Any]:
+    if isinstance(value, InitialAssignment):
+        return _fn_to_node_dict(value.fn, origin=origin, args=value.args)
+    return mml.Num(value=float(value)).to_dict()
+
+
+def _stoich_to_node_dict(
+    value: float | Derived,
+    *,
+    origin: str,
+) -> dict[str, Any]:
+    if isinstance(value, Derived):
+        return _fn_to_node_dict(value.fn, origin=origin, args=value.args)
+    return mml.Num(value=float(value)).to_dict()
+
+
+def model_to_dict(
+    model: Model,
+    *,
+    model_id: str,
+    description: str = "",
+) -> dict[str, Any]:
+    """Convert a model into its ``.mxl.json`` dict representation.
+
+    Parameters
+    ----------
+    model
+        Model to serialise
+    model_id
+        Identifier stored in the file
+    description
+        Human-readable description stored in the file
+
+    Returns
+    -------
+    dict
+        JSON-compatible mapping following the ``mxl-model`` schema
+
+    Raises
+    ------
+    SerializationError
+        If the model contains surrogates or a rate function that cannot be
+        converted into an expression.
+
+    """
+    if model._surrogates:  # noqa: SLF001
+        names = ", ".join(sorted(model._surrogates))  # noqa: SLF001
+        msg = f"surrogates are not supported: {names}"
+        raise SerializationError(msg)
+
+    variables = {
+        name: {"value": _value_to_node_dict(var.initial_value, origin=name)}
+        for name, var in model.get_raw_variables().items()
+    }
+    parameters = {
+        name: {"value": _value_to_node_dict(par.value, origin=name)}
+        for name, par in model.get_raw_parameters().items()
+    }
+    reactions = [
+        {
+            "name": name,
+            "fn": _fn_to_node_dict(rxn.fn, origin=name, args=rxn.args),
+            "stoichiometry": {
+                var: _stoich_to_node_dict(stoich, origin=f"{name}:{var}")
+                for var, stoich in rxn.stoichiometry.items()
+            },
+        }
+        for name, rxn in model.get_raw_reactions().items()
+    ]
+    derived = {
+        name: {"fn": _fn_to_node_dict(der.fn, origin=name, args=der.args)}
+        for name, der in model.get_raw_derived().items()
+    }
+    readouts = {
+        name: {"fn": _fn_to_node_dict(rdt.fn, origin=name, args=rdt.args)}
+        for name, rdt in model.get_raw_readouts().items()
+    }
+
+    return {
+        "$schema": SCHEMA_URL,
+        "spec_version": SPEC_VERSION,
+        "model_id": model_id,
+        "description": description,
+        "model": {
+            "variables": variables,
+            "parameters": parameters,
+            "reactions": reactions,
+            "derived": derived,
+            "readouts": readouts,
+        },
+    }
+
+
+def save(
+    model: Model,
+    path: str | Path,
+    *,
+    model_id: str | None = None,
+    description: str = "",
+) -> None:
+    """Save a model to the native ``.mxl.json`` format.
+
+    Parameters
+    ----------
+    model
+        Model to save
+    path
+        Destination file path
+    model_id
+        Identifier stored in the file. Defaults to the file name stem.
+    description
+        Human-readable description stored in the file
+
+    Raises
+    ------
+    SerializationError
+        If the model contains surrogates or a rate function that cannot be
+        converted into an expression.
+
+    """
+    path = Path(path)
+    if model_id is None:
+        model_id = path.name.removesuffix(".json").removesuffix(".mxl")
+    data = model_to_dict(model, model_id=model_id, description=description)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+###############################################################################
+# Load
+###############################################################################
+
+
+def _compile_fn(expr: sympy.Expr, args: list[str]) -> Callable[..., float]:
+    src = sympy_to_python_fn(fn_name=_FN_NAME, args=args, expr=expr)
+    # Register the source in linecache under a unique filename so that
+    # inspect.getsource (and thus fn_to_sympy_expr / codegen) can recover it,
+    # which keeps loaded models re-serialisable and introspectable.
+    filename = f"<mxlpy-generated-{uuid.uuid4().hex}>"
+    linecache.cache[filename] = (
+        len(src),
+        None,
+        src.splitlines(keepends=True),
+        filename,
+    )
+    namespace: dict[str, Any] = {
+        "math": math,
+        "numpy": np,
+        "np": np,
+        "scipy": scipy,
+    }
+    exec(compile(src, filename, "exec"), namespace)  # noqa: S102
+    return namespace[_FN_NAME]
+
+
+def _node_dict_to_fn(
+    node_dict: dict[str, Any],
+) -> tuple[Callable[..., float], list[str]]:
+    expr = mathml_to_sympy(mml.node_from_dict(node_dict))
+    args = sorted(str(s) for s in expr.free_symbols)
+    return _compile_fn(expr, args), args
+
+
+def _node_dict_to_value(node_dict: dict[str, Any]) -> float | InitialAssignment:
+    if node_dict["type"] == "Num":
+        return float(node_dict["value"])
+    fn, args = _node_dict_to_fn(node_dict)
+    return InitialAssignment(fn=fn, args=args)
+
+
+def _node_dict_to_stoich(node_dict: dict[str, Any]) -> float | Derived:
+    expr = mathml_to_sympy(mml.node_from_dict(node_dict))
+    if expr.is_number:
+        return float(expr)
+    fn, args = _node_dict_to_fn(node_dict)
+    return Derived(fn=fn, args=args)
+
+
+def model_from_dict(data: Mapping[str, Any]) -> Model:
+    """Reconstruct a model from its ``.mxl.json`` dict representation.
+
+    Parameters
+    ----------
+    data
+        Mapping following the ``mxl-model`` schema
+
+    Returns
+    -------
+    Model
+        The reconstructed model
+
+    """
+    spec = data["model"]
+    model = Model()
+
+    for name, par in spec["parameters"].items():
+        model.add_parameter(name, _node_dict_to_value(par["value"]))
+    for name, var in spec["variables"].items():
+        model.add_variable(name, _node_dict_to_value(var["value"]))
+    for name, der in spec["derived"].items():
+        fn, args = _node_dict_to_fn(der["fn"])
+        model.add_derived(name, fn, args=args)
+    for rxn in spec["reactions"]:
+        fn, args = _node_dict_to_fn(rxn["fn"])
+        stoichiometry = {
+            var: _node_dict_to_stoich(node)
+            for var, node in rxn["stoichiometry"].items()
+        }
+        model.add_reaction(rxn["name"], fn, args=args, stoichiometry=stoichiometry)
+    for name, rdt in spec["readouts"].items():
+        fn, args = _node_dict_to_fn(rdt["fn"])
+        model.add_readout(name, fn, args=args)
+
+    return model
+
+
+def load(path: str | Path) -> Model:
+    """Load a model from the native ``.mxl.json`` format.
+
+    Parameters
+    ----------
+    path
+        Source file path
+
+    Returns
+    -------
+    Model
+        The reconstructed model
+
+    """
+    data = json.loads(Path(path).read_text())
+    return model_from_dict(data)

--- a/src/mxlpy/serialize.py
+++ b/src/mxlpy/serialize.py
@@ -65,7 +65,7 @@ SPEC_VERSION = "1.0"
 _SCHEMA_MAJOR = SPEC_VERSION.split(".", 1)[0]
 SCHEMA_URL = (
     "https://raw.githubusercontent.com/Computational-Biology-Aachen/"
-    f"mxl-schemas/main/v{_SCHEMA_MAJOR}/mxl-model.schema.json"
+    f"mxl-schemas/main/v{_SCHEMA_MAJOR}/kinetic-model.schema.json"
 )
 
 _FN_NAME = "_mxl_fn"

--- a/src/mxlpy/serialize.py
+++ b/src/mxlpy/serialize.py
@@ -151,9 +151,8 @@ def model_to_dict(
         name: {"value": _value_to_node_dict(par.value, origin=name)}
         for name, par in model.get_raw_parameters().items()
     }
-    reactions = [
-        {
-            "name": name,
+    reactions = {
+        name: {
             "fn": _fn_to_node_dict(rxn.fn, origin=name, args=rxn.args),
             "stoichiometry": {
                 var: _stoich_to_node_dict(stoich, origin=f"{name}:{var}")
@@ -161,7 +160,7 @@ def model_to_dict(
             },
         }
         for name, rxn in model.get_raw_reactions().items()
-    ]
+    }
     derived = {
         name: {"fn": _fn_to_node_dict(der.fn, origin=name, args=der.args)}
         for name, der in model.get_raw_derived().items()
@@ -294,13 +293,13 @@ def model_from_dict(data: Mapping[str, Any]) -> Model:
     for name, der in spec["derived"].items():
         fn, args = _node_dict_to_fn(der["fn"])
         model.add_derived(name, fn, args=args)
-    for rxn in spec["reactions"]:
+    for name, rxn in spec["reactions"].items():
         fn, args = _node_dict_to_fn(rxn["fn"])
         stoichiometry = {
             var: _node_dict_to_stoich(node)
             for var, node in rxn["stoichiometry"].items()
         }
-        model.add_reaction(rxn["name"], fn, args=args, stoichiometry=stoichiometry)
+        model.add_reaction(name, fn, args=args, stoichiometry=stoichiometry)
     for name, rdt in spec["readouts"].items():
         fn, args = _node_dict_to_fn(rdt["fn"])
         model.add_readout(name, fn, args=args)

--- a/src/mxlpy/types.py
+++ b/src/mxlpy/types.py
@@ -49,6 +49,7 @@ __all__ = [
     "Result",
     "RetType",
     "Rhs",
+    "SerializationError",
     "Variable",
 ]
 
@@ -140,6 +141,24 @@ class FitFailure(Exception):
         """Initialise."""
         super().__init__(self.message)
         self.extra_info = [] if extra_info is None else extra_info
+
+
+class SerializationError(Exception):
+    """Raised when a model cannot be serialised to the native JSON format."""
+
+    message: str = "Failed to serialize model."
+
+    def __init__(self, detail: str | None = None) -> None:
+        """Initialise.
+
+        Parameters
+        ----------
+        detail
+            Optional context, e.g. the name of the offending model element.
+
+        """
+        super().__init__(self.message if detail is None else f"{self.message} {detail}")
+        self.detail = detail
 
 
 @dataclass(slots=True)

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -1,0 +1,241 @@
+"""Tests for native JSON model serialization (mxlpy.save / mxlpy.load)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+import sympy
+from numpy.polynomial import polynomial
+
+import mxlpy
+from example_models import (
+    get_linear_chain_2v,
+    get_lotka_volterra,
+    get_sir,
+    get_sird,
+    get_tpi_ald_model,
+    get_upper_glycolysis,
+)
+from mxlpy import Derived, InitialAssignment, Model, fns
+from mxlpy.meta import _mathml as mml
+from mxlpy.meta.sympy_tools import mathml_to_sympy, sympy_to_mathml
+from mxlpy.serialize import model_from_dict, model_to_dict
+from mxlpy.surrogates._poly import Surrogate
+from mxlpy.types import SerializationError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pandas as pd
+
+EXAMPLE_MODELS = [
+    get_linear_chain_2v,
+    get_lotka_volterra,
+    get_sir,
+    get_sird,
+    get_tpi_ald_model,
+    get_upper_glycolysis,
+]
+
+
+def _combined(model: Model) -> pd.DataFrame:
+    res = mxlpy.Simulator(model).simulate(10).get_result().unwrap_or_err()
+    return res.get_combined()
+
+
+###############################################################################
+# Node tree <-> dict
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "node",
+    [
+        mml.Num(value=1.5),
+        mml.Name(name="k1"),
+        mml.Pi(),
+        mml.E(),
+        mml.Bool(value=True),
+        mml.Bool(value=False),
+        mml.Sin(mml.Name(name="x")),
+        mml.Pow(left=mml.Name(name="x"), right=mml.Num(value=2.0)),
+        mml.Sqrt(child=mml.Name(name="x"), base=mml.Num(value=2.0)),
+        mml.Log(child=mml.Name(name="x"), base=mml.Num(value=10.0)),
+        mml.Add([mml.Name(name="x"), mml.Num(value=1.0)]),
+        mml.Mul([mml.Name(name="x"), mml.Name(name="y"), mml.Num(value=3.0)]),
+        mml.Piecewise([mml.Num(value=1.0), mml.Name(name="cond"), mml.Num(value=0.0)]),
+    ],
+)
+def test_node_dict_roundtrip(node: mml.Base) -> None:
+    assert mml.node_from_dict(node.to_dict()) == node
+
+
+def test_node_leaf_dict_shapes() -> None:
+    assert mml.Num(value=2.0).to_dict() == {"type": "Num", "value": 2.0}
+    assert mml.Name(name="k1").to_dict() == {"type": "Name", "value": "k1"}
+    assert mml.Pi().to_dict() == {"type": "Pi"}
+    assert mml.Bool(value=True).to_dict() == {"type": "Bool", "value": True}
+
+
+def test_node_arity_dict_shapes() -> None:
+    assert mml.Sin(mml.Name(name="x")).to_dict() == {
+        "type": "Sin",
+        "child": {"type": "Name", "value": "x"},
+    }
+    assert mml.Pow(left=mml.Name(name="x"), right=mml.Num(value=2.0)).to_dict() == {
+        "type": "Pow",
+        "left": {"type": "Name", "value": "x"},
+        "right": {"type": "Num", "value": 2.0},
+    }
+    assert mml.Add([mml.Num(value=1.0)]).to_dict() == {
+        "type": "Add",
+        "children": [{"type": "Num", "value": 1.0}],
+    }
+
+
+def test_node_from_dict_unknown_type() -> None:
+    with pytest.raises(ValueError, match="Unknown expression node type"):
+        mml.node_from_dict({"type": "Nope"})
+
+
+###############################################################################
+# sympy <-> node tree
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        sympy.Symbol("k1") * sympy.Symbol("A"),
+        sympy.Symbol("k1") * sympy.Symbol("A") - sympy.Symbol("k2"),
+        sympy.Symbol("x") ** 2,
+        sympy.sqrt(sympy.Symbol("x")),
+        sympy.Symbol("a") / sympy.Symbol("b"),
+        -sympy.Symbol("x"),
+        sympy.exp(sympy.Symbol("x")) + sympy.sin(sympy.Symbol("y")),
+        sympy.Max(sympy.Symbol("x"), sympy.Symbol("y")),
+        sympy.Piecewise(
+            (sympy.Symbol("x"), sympy.Symbol("x") > 0), (sympy.Integer(0), True)
+        ),
+    ],
+)
+def test_sympy_tree_roundtrip(expr: sympy.Expr) -> None:
+    restored = mathml_to_sympy(sympy_to_mathml(expr))
+    assert sympy.simplify(restored - expr) == 0
+
+
+def test_sympy_constants_roundtrip() -> None:
+    assert sympy_to_mathml(sympy.pi) == mml.Pi()
+    assert sympy_to_mathml(sympy.E) == mml.E()
+    assert mathml_to_sympy(mml.Pi()) == sympy.pi
+    assert mathml_to_sympy(mml.E()) == sympy.E
+
+
+###############################################################################
+# Full model round-trip
+###############################################################################
+
+
+@pytest.mark.parametrize("getter", EXAMPLE_MODELS)
+def test_example_model_roundtrip_simulates_identically(getter) -> None:  # noqa: ANN001
+    model = getter()
+    spec = model_to_dict(model, model_id="m")
+    restored = model_from_dict(spec)
+
+    original = _combined(model)
+    loaded = _combined(restored)
+    common = sorted(set(original.columns) & set(loaded.columns))
+    assert set(original.columns) == set(loaded.columns)
+    assert np.allclose(
+        original[common].to_numpy(), loaded[common].to_numpy(), rtol=1e-6, atol=1e-8
+    )
+
+
+@pytest.mark.parametrize("getter", EXAMPLE_MODELS)
+def test_save_load_save_is_idempotent(getter, tmp_path: Path) -> None:  # noqa: ANN001
+    model = getter()
+    first = tmp_path / "a.mxl.json"
+    second = tmp_path / "b.mxl.json"
+
+    mxlpy.save(model, first, model_id="m")
+    mxlpy.save(mxlpy.load(first), second, model_id="m")
+
+    assert first.read_text() == second.read_text()
+
+
+def test_save_writes_schema_and_default_model_id(tmp_path: Path) -> None:
+    path = tmp_path / "glycolysis.mxl.json"
+    mxlpy.save(get_lotka_volterra(), path)
+    data = json.loads(path.read_text())
+
+    assert data["$schema"].endswith("mxl-model.schema.json")
+    assert data["spec_version"] == "1.0"
+    assert data["model_id"] == "glycolysis"
+    assert set(data["model"]) == {
+        "variables",
+        "parameters",
+        "reactions",
+        "derived",
+        "readouts",
+    }
+
+
+def test_initial_assignment_roundtrip() -> None:
+    model = (
+        Model()
+        .add_parameters({"p1": 2.0, "p2": 3.0})
+        .add_variable("v1", InitialAssignment(fn=fns.mul, args=["p1", "p2"]))
+    )
+    restored = model_from_dict(model_to_dict(model, model_id="m"))
+
+    raw = restored.get_raw_variables()["v1"]
+    assert isinstance(raw.initial_value, InitialAssignment)
+    assert restored.get_initial_conditions()["v1"] == pytest.approx(6.0)
+
+
+def test_dynamic_stoichiometry_roundtrip() -> None:
+    model = (
+        Model()
+        .add_variables({"v1": 1.0, "v2": 1.0})
+        .add_parameters({"p1": 1.0, "k": 2.0})
+        .add_reaction(
+            "r1",
+            fn=fns.mass_action_1s,
+            args=["v1", "p1"],
+            stoichiometry={"v1": -1.0, "v2": Derived(fn=fns.mul, args=["k", "p1"])},
+        )
+    )
+    restored = model_from_dict(model_to_dict(model, model_id="m"))
+    stoich = restored.get_raw_reactions()["r1"].stoichiometry
+    assert isinstance(stoich["v2"], Derived)
+    assert stoich["v1"] == pytest.approx(-1.0)
+
+
+def test_readout_roundtrip() -> None:
+    model = (
+        Model()
+        .add_variables({"v1": 2.0, "v2": 4.0})
+        .add_readout("ratio", fn=fns.div, args=["v1", "v2"])
+    )
+    restored = model_from_dict(model_to_dict(model, model_id="m"))
+    assert "ratio" in restored.get_raw_readouts()
+
+
+###############################################################################
+# Error handling
+###############################################################################
+
+
+def test_surrogate_raises_serialization_error() -> None:
+    surrogate = Surrogate(
+        model=polynomial.Polynomial([0, 1]),
+        args=["v1"],
+        outputs=["o1"],
+        stoichiometries={},
+    )
+    model = Model().add_variable("v1", 1.0).add_surrogate("s1", surrogate)
+    with pytest.raises(SerializationError, match="surrogates"):
+        model_to_dict(model, model_id="m")

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -171,7 +171,7 @@ def test_save_writes_schema_and_default_model_id(tmp_path: Path) -> None:
     mxlpy.save(get_lotka_volterra(), path)
     data = json.loads(path.read_text())
 
-    assert data["$schema"].endswith("mxl-model.schema.json")
+    assert data["$schema"].endswith("kinetic-model.schema.json")
     assert data["spec_version"] == "1.0"
     assert data["model_id"] == "glycolysis"
     assert set(data["model"]) == {


### PR DESCRIPTION
## Summary

- Add `mxlpy.save(model, path)` / `mxlpy.load(path)` for a native, version-controllable `.mxl.json` format capturing the full model structure (variables, parameters, reactions, derived, readouts). Closes #118.
- **Tree-of-nodes, not `srepr()`**: rate expressions are stored as math-node trees using the node set shared with MxlWeb (`mxlpy.meta._mathml`), so the same files are consumable by both tools. Added the missing `Pi`/`E`/`Bool` leaves to fully match MxlWeb, plus `to_dict`/`node_from_dict` and `sympy_to_mathml`/`mathml_to_sympy` converters.
- Lossless round-trip: a loaded model uses generated rate functions and simulates identically; `save → load → save` is byte-idempotent.

## Design decisions (from discussion)

- **Arity-accurate JSON encoding** (`child` / `left`+`right` / `children`), leaves use `value`; symbol refs are `Name` (matching MathML/MxlWeb `<ci>`), not `Symbol`.
- **v1 scope**: models only — `units`, `source`, and protocols are deliberately dropped (the `spec_version` field allows adding them later).
- **Errors**: `SerializationError` is raised for surrogates or any rate function that can't be parsed into an expression.
- **sympy round-trip**: loaded functions are exec-generated and registered in `linecache`, so they stay introspectable (re-serialisation, LaTeX and codegen all work on loaded models).
- **Schema**: the JSON Schema lives in the separate, language-agnostic `mxl-schemas` repo (intentionally *not* vendored here). Files reference it via a version-pinned `$schema` URL for editor validation/autocomplete; reference-only, no runtime validation dependency. SBML remains the format for cross-tool interchange.

## Test plan

- `uv run pytest tests/test_serialize.py` — 43 tests: node `to_dict`/`from_dict` per arity, sympy↔tree round-trips, full example-model round-trips that simulate identically, `save→load→save` idempotency, dynamic stoichiometry, initial assignments, readouts, and `SerializationError` on surrogates.
- `uv run pytest tests/` — full suite green (2070 passed, 3 skipped).
- `uv run ruff check` / `uv run pyright` clean on new code (one remaining pyright error in `sympy_to_inline_mxlweb` pre-exists on `main`).
- Docs notebook `docs/serialization.ipynb` executes during build; `llms-advanced.txt` updated.