### PR TITLE
feat: add Model.rename to rename components and update references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ maintainers = [
 name = "mxlpy"
 readme = "README.md"
 requires-python = ">=3.12"
-version = "0.52.0"
+version = "0.53.0"
 
 [project.optional-dependencies]
 jax = ["diffrax>=0.7.0", "equinox>=0.13", "optax>=0.2.5", "sympy2jax>=0.0.7"]

--- a/src/mxlpy/model.py
+++ b/src/mxlpy/model.py
@@ -12,7 +12,7 @@ import inspect
 import itertools as it
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 import numpy as np
 import pandas as pd
@@ -1916,6 +1916,134 @@ class Model:
     #         compound=compound,
     #         value=self.stoichiometries[rate_name][compound] * scale,
     #     )
+
+    ##########################################################################
+    # Rename
+    ##########################################################################
+
+    def _rename_references(self, old_name: str, new_name: str) -> None:
+        """Replace every reference to ``old_name`` with ``new_name`` in place.
+
+        Rewrites all ``args`` lists and stoichiometry keys across the model. The
+        owning slot itself is handled by :meth:`rename`.
+
+        Parameters
+        ----------
+        old_name
+            The name currently being referenced.
+        new_name
+            The name to reference instead.
+
+        """
+
+        def rename_args(args: list[str]) -> list[str]:
+            return [new_name if arg == old_name else arg for arg in args]
+
+        def rename_stoich(
+            stoich: Mapping[str, float | Derived],
+        ) -> dict[str, float | Derived]:
+            result: dict[str, float | Derived] = {}
+            for cpd, factor in stoich.items():
+                if isinstance(factor, Derived):
+                    factor.args = rename_args(factor.args)
+                result[new_name if cpd == old_name else cpd] = factor
+            return result
+
+        # Initial assignments on variables and parameters
+        for variable in self._variables.values():
+            if isinstance(init := variable.initial_value, InitialAssignment):
+                init.args = rename_args(init.args)
+        for parameter in self._parameters.values():
+            if isinstance(value := parameter.value, InitialAssignment):
+                value.args = rename_args(value.args)
+
+        # Args of derived values and readouts
+        for derived in self._derived.values():
+            derived.args = rename_args(derived.args)
+        for readout in self._readouts.values():
+            readout.args = rename_args(readout.args)
+
+        # Args and stoichiometries of reactions
+        for reaction in self._reactions.values():
+            reaction.args = rename_args(reaction.args)
+            reaction.stoichiometry = rename_stoich(reaction.stoichiometry)
+
+        # Args and stoichiometries of surrogates
+        for surrogate in self._surrogates.values():
+            surrogate.args = rename_args(surrogate.args)
+            surrogate.stoichiometries = {
+                (new_name if flux == old_name else flux): rename_stoich(stoich)
+                for flux, stoich in surrogate.stoichiometries.items()
+            }
+
+    @_invalidate_cache
+    def rename(self, old_name: str, new_name: str) -> Self:
+        """Rename a model component and update all references to it.
+
+        Renames any registered name - variable, parameter, derived, reaction,
+        readout, surrogate, surrogate output or data set - and rewrites every
+        reference to it in ``args`` lists and stoichiometries.
+
+        Examples
+        --------
+            >>> model.rename("v1", "glucose")
+
+        Parameters
+        ----------
+        old_name
+            The current name of the component.
+        new_name
+            The new name for the component.
+
+        Returns
+        -------
+        Self
+            The instance of the model with the component renamed.
+
+        Raises
+        ------
+        KeyError
+            If ``old_name`` is not a registered name, or ``new_name`` is the
+            reserved ``"time"`` identifier.
+        NameError
+            If ``new_name`` already exists in the model.
+
+        """
+        if old_name == new_name:
+            return self
+
+        ctx = self._ids[old_name]  # KeyError if old_name is unknown
+        # Insert before remove so a collision or reserved name raises before
+        # any part of the model is mutated.
+        self._insert_id(name=new_name, ctx=ctx)
+        self._remove_id(name=old_name)
+
+        # Move the owning slot
+        containers: list[dict[str, Any]] = [
+            self._variables,
+            self._parameters,
+            self._derived,
+            self._readouts,
+            self._reactions,
+            self._surrogates,
+            self._data,
+        ]
+        for container in containers:
+            if old_name in container:
+                container[new_name] = container.pop(old_name)
+                break
+        else:
+            # Surrogate output: lives in a surrogate's `outputs` list
+            for surrogate in self._surrogates.values():
+                if old_name in surrogate.outputs:
+                    surrogate.outputs = [
+                        new_name if out == old_name else out
+                        for out in surrogate.outputs
+                    ]
+                    break
+
+        self._rename_references(old_name, new_name)
+        return self
 
     ##########################################################################
     # DSLs

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4,7 +4,13 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from mxlpy import Derived, InitialAssignment, Simulator
 from mxlpy.model import Model
+from mxlpy.surrogates import qss
+
+
+def qss_single_output(v1: float) -> tuple[float]:
+    return (v1 * 2.0,)
 
 
 def no_arguments() -> float:
@@ -1292,3 +1298,240 @@ def test_get_right_hand_side_empty_concs() -> None:
     )
     with pytest.raises(KeyError):
         model.get_right_hand_side({})
+
+
+# ---------------------------------------------------------------------------
+# rename
+# ---------------------------------------------------------------------------
+
+
+def test_rename_variable() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_reaction(
+            "r1",
+            fn=one_argument,
+            args=["v1"],
+            stoichiometry={"v1": -1.0},
+        )
+    )
+    model.rename("v1", "x")
+
+    assert "x" in model.get_variable_names()
+    assert "v1" not in model.get_variable_names()
+    assert model._ids["x"] == "variable"
+    assert "v1" not in model._ids
+    rxn = model.get_raw_reactions(as_copy=False)["r1"]
+    assert rxn.args == ["x"]
+    assert "x" in rxn.stoichiometry
+    assert "v1" not in rxn.stoichiometry
+
+
+def test_rename_parameter() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_parameter("p1", 2.0)
+        .add_derived("d1", fn=two_arguments, args=["v1", "p1"])
+    )
+    model.rename("p1", "k")
+
+    assert "k" in model.get_parameter_names()
+    assert "p1" not in model._ids
+    assert model.get_raw_derived(as_copy=False)["d1"].args == ["v1", "k"]
+
+
+def test_rename_parameter_in_initial_assignment() -> None:
+    model = (
+        Model()
+        .add_parameter("p1", 2.0)
+        .add_variable("v1", InitialAssignment(fn=one_argument, args=["p1"]))
+    )
+    model.rename("p1", "k")
+
+    init = model.get_raw_variables(as_copy=False)["v1"].initial_value
+    assert isinstance(init, InitialAssignment)
+    assert init.args == ["k"]
+
+
+def test_rename_derived() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_derived("d1", fn=one_argument, args=["v1"])
+        .add_reaction(
+            "r1",
+            fn=one_argument,
+            args=["d1"],
+            stoichiometry={"v1": -1.0},
+        )
+    )
+    model.rename("d1", "flux")
+
+    assert "flux" in model.get_derived_variable_names()
+    assert model.get_raw_reactions(as_copy=False)["r1"].args == ["flux"]
+
+
+def test_rename_reaction() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_reaction(
+            "r1",
+            fn=one_argument,
+            args=["v1"],
+            stoichiometry={"v1": -1.0},
+        )
+        .add_readout("ro1", fn=one_argument, args=["r1"])
+    )
+    model.rename("r1", "uptake")
+
+    assert "uptake" in model.get_reaction_names()
+    assert "r1" not in model._ids
+    assert model._readouts["ro1"].args == ["uptake"]
+
+
+def test_rename_readout() -> None:
+    model = (
+        Model().add_variable("v1", 1.0).add_readout("ro1", fn=one_argument, args=["v1"])
+    )
+    model.rename("ro1", "energy")
+
+    assert "energy" in model.get_readout_names()
+    assert "ro1" not in model._ids
+
+
+def test_rename_surrogate() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_surrogate(
+            "qss1",
+            qss.Surrogate(
+                model=qss_single_output,
+                args=["v1"],
+                outputs=["out1"],
+                stoichiometries={"out1": {"v1": -1.0}},
+            ),
+        )
+    )
+    model.rename("qss1", "ml")
+
+    assert "ml" in model.get_raw_surrogates(as_copy=False)
+    assert "qss1" not in model._ids
+    # Outputs are unaffected when renaming the surrogate itself
+    assert model.get_raw_surrogates(as_copy=False)["ml"].outputs == ["out1"]
+
+
+def test_rename_surrogate_output() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_surrogate(
+            "qss1",
+            qss.Surrogate(
+                model=qss_single_output,
+                args=["v1"],
+                outputs=["out1"],
+                stoichiometries={"out1": {"v1": -1.0}},
+            ),
+        )
+        .add_readout("ro1", fn=one_argument, args=["out1"])
+    )
+    model.rename("out1", "flux")
+
+    surrogate = model.get_raw_surrogates(as_copy=False)["qss1"]
+    assert surrogate.outputs == ["flux"]
+    assert "flux" in surrogate.stoichiometries
+    assert "out1" not in surrogate.stoichiometries
+    assert "out1" not in model._ids
+    assert model._readouts["ro1"].args == ["flux"]
+
+
+def test_rename_data() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_data("d", pd.Series({"a": 1.0}))
+        .add_reaction(
+            "r1",
+            fn=two_arguments,
+            args=["v1", "d"],
+            stoichiometry={"v1": -1.0},
+        )
+    )
+    model.rename("d", "measured")
+
+    assert "measured" in model._data
+    assert "d" not in model._ids
+    assert model.get_raw_reactions(as_copy=False)["r1"].args == ["v1", "measured"]
+
+
+def test_rename_string_stoichiometry() -> None:
+    model = (
+        Model()
+        .add_variable("v1", 1.0)
+        .add_parameter("p1", 2.0)
+        .add_reaction(
+            "r1",
+            fn=one_argument,
+            args=["v1"],
+            stoichiometry={"v1": "p1"},
+        )
+    )
+    model.rename("p1", "k")
+
+    factor = model.get_raw_reactions(as_copy=False)["r1"].stoichiometry["v1"]
+    assert isinstance(factor, Derived)
+    assert factor.args == ["k"]
+
+
+def test_rename_missing_name() -> None:
+    model = Model().add_variable("v1", 1.0)
+    with pytest.raises(KeyError):
+        model.rename("nope", "x")
+
+
+def test_rename_collision() -> None:
+    model = Model().add_variables({"v1": 1.0, "v2": 2.0})
+    with pytest.raises(NameError):
+        model.rename("v1", "v2")
+    # Insert-before-remove: the model is left untouched
+    assert "v1" in model._ids
+    assert "v2" in model._ids
+
+
+def test_rename_to_time() -> None:
+    model = Model().add_variable("v1", 1.0)
+    with pytest.raises(KeyError):
+        model.rename("v1", "time")
+    assert "v1" in model._ids
+
+
+def test_rename_same_name_is_noop() -> None:
+    model = Model().add_variable("v1", 1.0)
+    assert model.rename("v1", "v1") is model
+    assert "v1" in model._ids
+
+
+def test_rename_preserves_dynamics() -> None:
+    def build(var: str, par: str) -> Model:
+        return (
+            Model()
+            .add_variable(var, 10.0)
+            .add_parameter(par, 0.5)
+            .add_reaction(
+                "r1",
+                fn=two_arguments,
+                args=[var, par],
+                stoichiometry={var: -1.0},
+            )
+        )
+
+    renamed = build("v1", "p1").rename("v1", "x").rename("p1", "k")
+    reference = build("x", "k")
+
+    res_renamed = Simulator(renamed).simulate(10).get_result().unwrap_or_err()
+    res_reference = Simulator(reference).simulate(10).get_result().unwrap_or_err()
+    pd.testing.assert_frame_equal(res_renamed.variables, res_reference.variables)

--- a/uv.lock
+++ b/uv.lock
@@ -2106,7 +2106,7 @@ wheels = [
 
 [[package]]
 name = "mxlpy"
-version = "0.52.0"
+version = "0.53.0"
 source = { editable = "." }
 dependencies = [
     { name = "dill" },


### PR DESCRIPTION
## Summary

- Add `Model.rename(old_name, new_name)`, a fluent method that renames **any** registered name — variable, parameter, derived, reaction, readout, surrogate, surrogate output, or data set — and rewrites every reference to it across `args` lists and stoichiometries (including string-coefficient stoichiometries, derived stoichiometry factors, and initial assignments).
- References are rewritten with a single flat scan over all components rather than a topological walk: a rename touches every referrer regardless of dependency depth, so dependency ordering is irrelevant.
- The `_ids` swap inserts the new name **before** removing the old one, so a name collision (`NameError`) or the reserved `time` name (`KeyError`) raises before the model is mutated, leaving it untouched on failure.
- Bump version to `0.53.0`.

## Test plan

- `uv run pytest tests/model/test_model.py` — 15 new `rename` tests cover each renameable kind, string stoichiometries, the four guards (missing name, collision-leaves-model-unchanged, reserved `time`, same-name no-op), and an integration test asserting a renamed model simulates identically to one built with the new names.
- `uv run pyright` — clean.